### PR TITLE
Updating video info for YT links

### DIFF
--- a/lib/provider/youtube.rb
+++ b/lib/provider/youtube.rb
@@ -23,8 +23,8 @@ private
     @keywords         = doc.search("media:keywords").inner_text
     @duration         = doc.search("yt:duration").first[:seconds].to_i
     @date             = Time.parse(doc.search("published").inner_text, Time.now.utc)
-    @thumbnail_small  = doc.search("media:thumbnail").first[:url]
-    @thumbnail_large  = doc.search("media:thumbnail").last[:url]
+    @thumbnail_small  = doc.search("media:thumbnail").last[:url]
+    @thumbnail_large  = doc.search("media:thumbnail").first[:url]
     # when your video still has no view, yt:statistics is not returned by Youtube
     # see: https://github.com/thibaudgg/video_info/issues#issue/2
     if doc.search("yt:statistics").first


### PR DESCRIPTION
Looks like Google changed the order of their XML.
