### PR TITLE
Vimeo videos can use one of two URL schemes

### DIFF
--- a/lib/provider/vimeo.rb
+++ b/lib/provider/vimeo.rb
@@ -8,7 +8,7 @@ class Vimeo
                 :view_count
   
   def initialize(url)
-    @video_id = url.gsub(/.*\.com\/([0-9]+).*$/i, '\1')
+    @video_id = url.gsub(/.*\.com\/(?:groups\/[^\/]+\/videos\/)?([0-9]+).*$/i, '\1')
     get_info unless @video_id == url
   end
   


### PR DESCRIPTION
I've modified the regex to allow both url types:
http://vimeo.com/*
http://vimeo.com/groups/*/videos/*

See http://vimeo.com/api/docs/oembed for reference regards url format.
