### PR TITLE
Move :iframe_attributes to .embed_code method, add :iframe_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,17 @@ User-Agent when empty defaults to "VideoInfo/VERSION" - where version is current
 
 It supports all openURI header fields (options), for more information see: [openURI DOCS](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/open-uri/rdoc/OpenURI.html)
 
-You can also include an `iframe_attributes` hash to include arbitrary attributes in the iframe embed code:
+You can also include an `iframe_attributes` or `url_attributes` hash to the `embed_code` method to include arbitrary attributes in the iframe embed code or as additional URL params:
 
 ``` ruby
-VideoInfo.get("http://www.youtube.com/watch?v=mZqGqE0D0n4", :iframe_attributes => { :width => 800, :height => 600, "data-key" => "value" } ).embed_code
-=> '<iframe src="http://www.youtube.com/embed/mZqGqE0D0n4" frameborder="0" allowfullscreen="allowfullscreen" width="800" height="600" data-key="value"></iframe>'
+VideoInfo.get("http://www.youtube.com/watch?v=mZqGqE0D0n4").embed_code(:iframe_attributes => { :width => 800, :height => 600, "data-key" => "value" })
+=> '<iframe src="http://www.youtube.com/embed/mZqGqE0D0n4" frameborder="0" allowfullscreen="allowfullscreen" width="800" height="600" data-key="value"></iframe>
+
+'VideoInfo.get("http://www.youtube.com/watch?v=mZqGqE0D0n4").embed_code(:url_attributes => { :autoplay => 1 })
+=> '<iframe src="http://www.youtube.com/embed/mZqGqE0D0n4?autoplay=1" frameborder="0" allowfullscreen="allowfullscreen"></iframe>'
 ```
+
+
 
 Author
 ------

--- a/lib/video_info/providers/vimeo.rb
+++ b/lib/video_info/providers/vimeo.rb
@@ -9,6 +9,19 @@ module VideoInfo
         url =~ /vimeo\.com/
       end
 
+      def default_iframe_attributes
+        {}
+      end
+
+      def default_url_attributes
+        {
+          :title => 0,
+          :byline => 0,
+          :portrait => 0,
+          :autoplay => 0
+        }
+      end
+
       private
 
       def _url_regex
@@ -18,10 +31,10 @@ module VideoInfo
       def _set_info_from_api
         uri   = open("http://vimeo.com/api/v2/video/#{video_id}.json", options)
         video = MultiJson.load(uri.read).first
+
         @provider         = "Vimeo"
         @url              = video['url']
         @embed_url        = "http://player.vimeo.com/video/#{video_id}"
-        @embed_code       = "<iframe src=\"#{embed_url}?title=0&amp;byline=0&amp;portrait=0&amp;autoplay=0\" frameborder=\"0\"#{iframe_attributes}></iframe>"
         @title            = video['title']
         @description      = video['description']
         @keywords         = video['tags']

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -9,6 +9,14 @@ module VideoInfo
         url =~ /(youtube\.com)|(youtu\.be)/
       end
 
+      def default_iframe_attributes
+        { :allowfullscreen => "allowfullscreen" }
+      end
+
+      def default_url_attributes
+        {}
+      end
+
       private
 
       def _url_regex
@@ -21,7 +29,6 @@ module VideoInfo
         @provider         = "YouTube"
         @url              = url
         @embed_url        = "http://www.youtube.com/embed/#{video_id}"
-        @embed_code       = "<iframe src=\"#{embed_url}\" frameborder=\"0\" allowfullscreen=\"allowfullscreen\"#{iframe_attributes}></iframe>"
         video['entry'].tap do |entry|
           @title            = entry['title']['$t']
           @description      = entry['media$group']['media$description']['$t']

--- a/lib/video_info/version.rb
+++ b/lib/video_info/version.rb
@@ -1,3 +1,3 @@
 module VideoInfo
-  VERSION = "1.3.2"
+  VERSION = "1.3.3"
 end

--- a/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Vimeo/with_video_898029_and_iframe_attributes/.yml
+++ b/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Vimeo/with_video_898029_and_iframe_attributes/.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://vimeo.com/api/v2/video/898029.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - VideoInfo/1.3.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache
+      X-Ratelimit-Limit:
+      - '3600'
+      X-Ratelimit-Remaining:
+      - '3594'
+      X-Ratelimit-Reset:
+      - '1367415023'
+      Expires:
+      - Wed, 01 May 2013 12:43:05 GMT
+      Last-Modified:
+      - Sat, 06 Apr 2013 12:44:47 GMT
+      Etag:
+      - ! '"3ad3f9769c0e86e3e1183eea27aba3a6"'
+      X-Ua-Compatible:
+      - IE=EmulateIE9,chrome=1
+      X-Dns-Prefetch-Control:
+      - 'on'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 01 May 2013 12:42:05 GMT
+      X-Varnish:
+      - '933702472'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish
+      X-Varnish-Cache:
+      - '0'
+      Connection:
+      - close
+      X-Vserver:
+      - 10.90.128.147
+    body:
+      encoding: US-ASCII
+      string: ! '[{"id":898029,"title":"Cherry Bloom - King Of The Knife","description":"The
+        first video from the upcoming album Secret Sounds, to download in-stores April
+        14. Checkout http:\/\/www.cherrybloom.net","url":"http:\/\/vimeo.com\/898029","upload_date":"2008-04-14
+        13:10:39","thumbnail_small":"http:\/\/b.vimeocdn.com\/ts\/343\/731\/34373130_100.jpg","thumbnail_medium":"http:\/\/b.vimeocdn.com\/ts\/343\/731\/34373130_200.jpg","thumbnail_large":"http:\/\/b.vimeocdn.com\/ts\/343\/731\/34373130_640.jpg","user_id":206215,"user_name":"Octave
+        Zangs","user_url":"http:\/\/vimeo.com\/octave","user_portrait_small":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_30.jpg","user_portrait_medium":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_75.jpg","user_portrait_large":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_100.jpg","user_portrait_huge":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_300.jpg","stats_number_of_likes":11,"stats_number_of_plays":4538,"stats_number_of_comments":4,"duration":175,"width":640,"height":360,"tags":"cherry
+        bloom, secret sounds, king of the knife, rock, alternative","embed_privacy":"anywhere"}]'
+    http_version: 
+  recorded_at: Wed, 01 May 2013 12:42:12 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Vimeo/with_video_898029_and_url_attributes/.yml
+++ b/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Vimeo/with_video_898029_and_url_attributes/.yml
@@ -1,0 +1,67 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://vimeo.com/api/v2/video/898029.json
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - VideoInfo/1.3.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache
+      X-Ratelimit-Limit:
+      - '3600'
+      X-Ratelimit-Remaining:
+      - '3593'
+      X-Ratelimit-Reset:
+      - '1367415023'
+      Expires:
+      - Wed, 01 May 2013 13:04:28 GMT
+      Last-Modified:
+      - Sat, 06 Apr 2013 12:44:47 GMT
+      Etag:
+      - ! '"3ad3f9769c0e86e3e1183eea27aba3a6"'
+      X-Ua-Compatible:
+      - IE=EmulateIE9,chrome=1
+      X-Dns-Prefetch-Control:
+      - 'on'
+      Vary:
+      - Accept-Encoding
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Date:
+      - Wed, 01 May 2013 13:03:29 GMT
+      X-Varnish:
+      - '2125813546'
+      Age:
+      - '0'
+      Via:
+      - 1.1 varnish
+      X-Varnish-Cache:
+      - '0'
+      Connection:
+      - close
+      X-Vserver:
+      - 10.90.128.196
+    body:
+      encoding: US-ASCII
+      string: ! '[{"id":898029,"title":"Cherry Bloom - King Of The Knife","description":"The
+        first video from the upcoming album Secret Sounds, to download in-stores April
+        14. Checkout http:\/\/www.cherrybloom.net","url":"http:\/\/vimeo.com\/898029","upload_date":"2008-04-14
+        13:10:39","thumbnail_small":"http:\/\/b.vimeocdn.com\/ts\/343\/731\/34373130_100.jpg","thumbnail_medium":"http:\/\/b.vimeocdn.com\/ts\/343\/731\/34373130_200.jpg","thumbnail_large":"http:\/\/b.vimeocdn.com\/ts\/343\/731\/34373130_640.jpg","user_id":206215,"user_name":"Octave
+        Zangs","user_url":"http:\/\/vimeo.com\/octave","user_portrait_small":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_30.jpg","user_portrait_medium":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_75.jpg","user_portrait_large":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_100.jpg","user_portrait_huge":"http:\/\/b.vimeocdn.com\/ps\/257\/715\/2577152_300.jpg","stats_number_of_likes":11,"stats_number_of_plays":4538,"stats_number_of_comments":4,"duration":175,"width":640,"height":360,"tags":"cherry
+        bloom, secret sounds, king of the knife, rock, alternative","embed_privacy":"anywhere"}]'
+    http_version: 
+  recorded_at: Wed, 01 May 2013 13:03:36 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Youtube/with_arbitrary_iframe_attributes/.yml
+++ b/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Youtube/with_arbitrary_iframe_attributes/.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4?alt=json&v=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - VideoInfo/1.3.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - NL
+      Content-Type:
+      - application/json; charset=UTF-8
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Expires:
+      - Wed, 01 May 2013 12:46:26 GMT
+      Date:
+      - Wed, 01 May 2013 12:46:26 GMT
+      Cache-Control:
+      - private, max-age=300, no-transform
+      Vary:
+      - ! '*'
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"D0AFQH47eCp7I2A9WhBXE0g."
+      Last-Modified:
+      - Wed, 27 Mar 2013 03:41:51 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: ! '{"version":"1.0","encoding":"UTF-8","entry":{"xmlns":"http://www.w3.org/2005/Atom","xmlns$media":"http://search.yahoo.com/mrss/","xmlns$gd":"http://schemas.google.com/g/2005","xmlns$yt":"http://gdata.youtube.com/schemas/2007","gd$etag":"W/\"D0AFQH47eCp7I2A9WhBXE0g.\"","id":{"$t":"tag:youtube.com,2008:video:mZqGqE0D0n4"},"published":{"$t":"2008-04-12T22:25:35.000Z"},"updated":{"$t":"2013-03-27T03:41:51.000Z"},"category":[{"scheme":"http://schemas.google.com/g/2005#kind","term":"http://gdata.youtube.com/schemas/2007#video"},{"scheme":"http://gdata.youtube.com/schemas/2007/categories.cat","term":"Music","label":"Music"}],"title":{"$t":"Cherry
+        Bloom - King Of The Knife"},"content":{"type":"application/x-shockwave-flash","src":"http://www.youtube.com/v/mZqGqE0D0n4?version=3&f=videos&app=youtube_gdata"},"link":[{"rel":"alternate","type":"text/html","href":"http://www.youtube.com/watch?v=mZqGqE0D0n4&feature=youtube_gdata"},{"rel":"http://gdata.youtube.com/schemas/2007#video.responses","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4/responses?v=2"},{"rel":"http://gdata.youtube.com/schemas/2007#video.related","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4/related?v=2"},{"rel":"http://gdata.youtube.com/schemas/2007#uploader","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/users/zxQk-rZGowoqMBKxGD5jSA?v=2"},{"rel":"self","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4?v=2"}],"author":[{"name":{"$t":"cherrybloomband"},"uri":{"$t":"http://gdata.youtube.com/feeds/api/users/cherrybloomband"},"yt$userId":{"$t":"zxQk-rZGowoqMBKxGD5jSA"}}],"yt$accessControl":[{"action":"comment","permission":"allowed"},{"action":"commentVote","permission":"allowed"},{"action":"videoRespond","permission":"allowed"},{"action":"rate","permission":"allowed"},{"action":"embed","permission":"allowed"},{"action":"list","permission":"allowed"},{"action":"autoPlay","permission":"allowed"},{"action":"syndicate","permission":"allowed"}],"gd$comments":{"gd$feedLink":{"rel":"http://gdata.youtube.com/schemas/2007#comments","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4/comments?v=2","countHint":15}},"media$group":{"media$category":[{"$t":"Music","label":"Music","scheme":"http://gdata.youtube.com/schemas/2007/categories.cat"}],"media$content":[{"url":"http://www.youtube.com/v/mZqGqE0D0n4?version=3&f=videos&app=youtube_gdata","type":"application/x-shockwave-flash","medium":"video","isDefault":"true","expression":"full","duration":175,"yt$format":5},{"url":"rtsp://v8.cache3.c.youtube.com/CiILENy73wIaGQl-0gNNqIaamRMYDSANFEgGUgZ2aWRlb3MM/0/0/0/video.3gp","type":"video/3gpp","medium":"video","expression":"full","duration":175,"yt$format":1},{"url":"rtsp://v8.cache3.c.youtube.com/CiILENy73wIaGQl-0gNNqIaamRMYESARFEgGUgZ2aWRlb3MM/0/0/0/video.3gp","type":"video/3gpp","medium":"video","expression":"full","duration":175,"yt$format":6}],"media$credit":[{"$t":"cherrybloomband","role":"uploader","scheme":"urn:youtube","yt$display":"cherrybloomband"}],"media$description":{"$t":"The
+        first video from the upcoming album Secret Sounds, to download in-stores April
+        14. Checkout http://www.cherrybloom.net","type":"plain"},"media$keywords":{},"media$license":{"$t":"youtube","type":"text/html","href":"http://www.youtube.com/t/terms"},"media$player":{"url":"http://www.youtube.com/watch?v=mZqGqE0D0n4&feature=youtube_gdata_player"},"media$thumbnail":[{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/default.jpg","height":90,"width":120,"time":"00:01:27.500","yt$name":"default"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/mqdefault.jpg","height":180,"width":320,"yt$name":"mqdefault"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/hqdefault.jpg","height":360,"width":480,"yt$name":"hqdefault"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/1.jpg","height":90,"width":120,"time":"00:00:43.750","yt$name":"start"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/2.jpg","height":90,"width":120,"time":"00:01:27.500","yt$name":"middle"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/3.jpg","height":90,"width":120,"time":"00:02:11.250","yt$name":"end"}],"media$title":{"$t":"Cherry
+        Bloom - King Of The Knife","type":"plain"},"yt$duration":{"seconds":"175"},"yt$uploaded":{"$t":"2008-04-12T22:25:35.000Z"},"yt$uploaderId":{"$t":"UCzxQk-rZGowoqMBKxGD5jSA"},"yt$videoid":{"$t":"mZqGqE0D0n4"}},"gd$rating":{"average":4.822222,"max":5,"min":1,"numRaters":45,"rel":"http://schemas.google.com/g/2005#overall"},"yt$statistics":{"favoriteCount":"0","viewCount":"6120"},"yt$rating":{"numDislikes":"2","numLikes":"43"}}}'
+    http_version: 
+  recorded_at: Wed, 01 May 2013 12:46:33 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Youtube/with_iframe_attributes/.yml
+++ b/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Youtube/with_iframe_attributes/.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4?alt=json&v=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - VideoInfo/1.3.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - NL
+      Content-Type:
+      - application/json; charset=UTF-8
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Expires:
+      - Wed, 01 May 2013 12:45:25 GMT
+      Date:
+      - Wed, 01 May 2013 12:45:25 GMT
+      Cache-Control:
+      - private, max-age=300, no-transform
+      Vary:
+      - ! '*'
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"D0AFQH47eCp7I2A9WhBXE0g."
+      Last-Modified:
+      - Wed, 27 Mar 2013 03:41:51 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: ! '{"version":"1.0","encoding":"UTF-8","entry":{"xmlns":"http://www.w3.org/2005/Atom","xmlns$media":"http://search.yahoo.com/mrss/","xmlns$gd":"http://schemas.google.com/g/2005","xmlns$yt":"http://gdata.youtube.com/schemas/2007","gd$etag":"W/\"D0AFQH47eCp7I2A9WhBXE0g.\"","id":{"$t":"tag:youtube.com,2008:video:mZqGqE0D0n4"},"published":{"$t":"2008-04-12T22:25:35.000Z"},"updated":{"$t":"2013-03-27T03:41:51.000Z"},"category":[{"scheme":"http://schemas.google.com/g/2005#kind","term":"http://gdata.youtube.com/schemas/2007#video"},{"scheme":"http://gdata.youtube.com/schemas/2007/categories.cat","term":"Music","label":"Music"}],"title":{"$t":"Cherry
+        Bloom - King Of The Knife"},"content":{"type":"application/x-shockwave-flash","src":"http://www.youtube.com/v/mZqGqE0D0n4?version=3&f=videos&app=youtube_gdata"},"link":[{"rel":"alternate","type":"text/html","href":"http://www.youtube.com/watch?v=mZqGqE0D0n4&feature=youtube_gdata"},{"rel":"http://gdata.youtube.com/schemas/2007#video.responses","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4/responses?v=2"},{"rel":"http://gdata.youtube.com/schemas/2007#video.related","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4/related?v=2"},{"rel":"http://gdata.youtube.com/schemas/2007#uploader","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/users/zxQk-rZGowoqMBKxGD5jSA?v=2"},{"rel":"self","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4?v=2"}],"author":[{"name":{"$t":"cherrybloomband"},"uri":{"$t":"http://gdata.youtube.com/feeds/api/users/cherrybloomband"},"yt$userId":{"$t":"zxQk-rZGowoqMBKxGD5jSA"}}],"yt$accessControl":[{"action":"comment","permission":"allowed"},{"action":"commentVote","permission":"allowed"},{"action":"videoRespond","permission":"allowed"},{"action":"rate","permission":"allowed"},{"action":"embed","permission":"allowed"},{"action":"list","permission":"allowed"},{"action":"autoPlay","permission":"allowed"},{"action":"syndicate","permission":"allowed"}],"gd$comments":{"gd$feedLink":{"rel":"http://gdata.youtube.com/schemas/2007#comments","href":"http://gdata.youtube.com/feeds/api/videos/mZqGqE0D0n4/comments?v=2","countHint":15}},"media$group":{"media$category":[{"$t":"Music","label":"Music","scheme":"http://gdata.youtube.com/schemas/2007/categories.cat"}],"media$content":[{"url":"http://www.youtube.com/v/mZqGqE0D0n4?version=3&f=videos&app=youtube_gdata","type":"application/x-shockwave-flash","medium":"video","isDefault":"true","expression":"full","duration":175,"yt$format":5},{"url":"rtsp://v8.cache3.c.youtube.com/CiILENy73wIaGQl-0gNNqIaamRMYDSANFEgGUgZ2aWRlb3MM/0/0/0/video.3gp","type":"video/3gpp","medium":"video","expression":"full","duration":175,"yt$format":1},{"url":"rtsp://v8.cache3.c.youtube.com/CiILENy73wIaGQl-0gNNqIaamRMYESARFEgGUgZ2aWRlb3MM/0/0/0/video.3gp","type":"video/3gpp","medium":"video","expression":"full","duration":175,"yt$format":6}],"media$credit":[{"$t":"cherrybloomband","role":"uploader","scheme":"urn:youtube","yt$display":"cherrybloomband"}],"media$description":{"$t":"The
+        first video from the upcoming album Secret Sounds, to download in-stores April
+        14. Checkout http://www.cherrybloom.net","type":"plain"},"media$keywords":{},"media$license":{"$t":"youtube","type":"text/html","href":"http://www.youtube.com/t/terms"},"media$player":{"url":"http://www.youtube.com/watch?v=mZqGqE0D0n4&feature=youtube_gdata_player"},"media$thumbnail":[{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/default.jpg","height":90,"width":120,"time":"00:01:27.500","yt$name":"default"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/mqdefault.jpg","height":180,"width":320,"yt$name":"mqdefault"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/hqdefault.jpg","height":360,"width":480,"yt$name":"hqdefault"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/1.jpg","height":90,"width":120,"time":"00:00:43.750","yt$name":"start"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/2.jpg","height":90,"width":120,"time":"00:01:27.500","yt$name":"middle"},{"url":"http://i.ytimg.com/vi/mZqGqE0D0n4/3.jpg","height":90,"width":120,"time":"00:02:11.250","yt$name":"end"}],"media$title":{"$t":"Cherry
+        Bloom - King Of The Knife","type":"plain"},"yt$duration":{"seconds":"175"},"yt$uploaded":{"$t":"2008-04-12T22:25:35.000Z"},"yt$uploaderId":{"$t":"UCzxQk-rZGowoqMBKxGD5jSA"},"yt$videoid":{"$t":"mZqGqE0D0n4"}},"gd$rating":{"average":4.822222,"max":5,"min":1,"numRaters":45,"rel":"http://schemas.google.com/g/2005#overall"},"yt$statistics":{"favoriteCount":"0","viewCount":"6120"},"yt$rating":{"numDislikes":"2","numLikes":"43"}}}'
+    http_version: 
+  recorded_at: Wed, 01 May 2013 12:45:33 GMT
+recorded_with: VCR 2.4.0

--- a/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Youtube/with_video_oQ49W_xKzKA/.yml
+++ b/spec/fixtures/vcr_cassettes/VideoInfo_Providers_Youtube/with_video_oQ49W_xKzKA/.yml
@@ -1,0 +1,58 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://gdata.youtube.com/feeds/api/videos/oQ49W_xKzKA?alt=json&v=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - VideoInfo/1.3.3
+      Accept:
+      - ! '*/*'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Gdata-User-Country:
+      - NL
+      Content-Type:
+      - application/json; charset=UTF-8
+      Access-Control-Allow-Origin:
+      - ! '*'
+      Expires:
+      - Wed, 01 May 2013 13:04:23 GMT
+      Date:
+      - Wed, 01 May 2013 13:04:23 GMT
+      Cache-Control:
+      - private, max-age=300, no-transform
+      Vary:
+      - ! '*'
+      Gdata-Version:
+      - '2.1'
+      Etag:
+      - W/"CE4AQn47eCp7I2A9Wx9XEks."
+      Last-Modified:
+      - Wed, 05 Jan 2011 21:29:03 GMT
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      Server:
+      - GSE
+    body:
+      encoding: US-ASCII
+      string: ! '{"version":"1.0","encoding":"UTF-8","entry":{"xmlns$app":"http://www.w3.org/2007/app","xmlns":"http://www.w3.org/2005/Atom","xmlns$media":"http://search.yahoo.com/mrss/","xmlns$gd":"http://schemas.google.com/g/2005","xmlns$yt":"http://gdata.youtube.com/schemas/2007","gd$etag":"W/\"CE4AQn47eCp7I2A9Wx9XEks.\"","id":{"$t":"tag:youtube.com,2008:video:oQ49W_xKzKA"},"published":{"$t":"2011-01-05T21:24:39.000Z"},"updated":{"$t":"2011-01-05T21:29:03.000Z"},"app$control":{"app$draft":{"$t":"yes"},"yt$incomplete":{}},"category":[{"scheme":"http://schemas.google.com/g/2005#kind","term":"http://gdata.youtube.com/schemas/2007#video"},{"scheme":"http://gdata.youtube.com/schemas/2007/categories.cat","term":"People","label":"People
+        & Blogs"}],"title":{"$t":"test3"},"content":{"type":"application/x-shockwave-flash","src":"http://www.youtube.com/v/oQ49W_xKzKA?version=3&f=videos&app=youtube_gdata"},"link":[{"rel":"alternate","type":"text/html","href":"http://www.youtube.com/watch?v=oQ49W_xKzKA&feature=youtube_gdata"},{"rel":"http://gdata.youtube.com/schemas/2007#video.responses","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/oQ49W_xKzKA/responses?v=2"},{"rel":"http://gdata.youtube.com/schemas/2007#video.related","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/oQ49W_xKzKA/related?v=2"},{"rel":"http://gdata.youtube.com/schemas/2007#mobile","type":"text/html","href":"http://m.youtube.com/details?v=oQ49W_xKzKA"},{"rel":"http://gdata.youtube.com/schemas/2007#uploader","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/users/D3uCEQGGRDKDXONecXCx9g?v=2"},{"rel":"self","type":"application/atom+xml","href":"http://gdata.youtube.com/feeds/api/videos/oQ49W_xKzKA?v=2"}],"author":[{"name":{"$t":"Julien
+        Desrosiers"},"uri":{"$t":"http://gdata.youtube.com/feeds/api/users/juliend2"},"yt$userId":{"$t":"D3uCEQGGRDKDXONecXCx9g"}}],"yt$accessControl":[{"action":"comment","permission":"allowed"},{"action":"commentVote","permission":"allowed"},{"action":"videoRespond","permission":"moderated"},{"action":"rate","permission":"allowed"},{"action":"embed","permission":"allowed"},{"action":"list","permission":"allowed"},{"action":"autoPlay","permission":"allowed"},{"action":"syndicate","permission":"allowed"}],"gd$comments":{"gd$feedLink":{"rel":"http://gdata.youtube.com/schemas/2007#comments","href":"http://gdata.youtube.com/feeds/api/videos/oQ49W_xKzKA/comments?v=2","countHint":0}},"media$group":{"media$category":[{"$t":"People","label":"People
+        & Blogs","scheme":"http://gdata.youtube.com/schemas/2007/categories.cat"}],"media$content":[{"url":"http://www.youtube.com/v/oQ49W_xKzKA?version=3&f=videos&app=youtube_gdata","type":"application/x-shockwave-flash","medium":"video","isDefault":"true","expression":"full","duration":2,"yt$format":5},{"url":"rtsp://v8.cache1.c.youtube.com/CiILENy73wIaGQmgzEr8Wz0OoRMYDSANFEgGUgZ2aWRlb3MM/0/0/0/video.3gp","type":"video/3gpp","medium":"video","expression":"full","duration":2,"yt$format":1},{"url":"rtsp://v8.cache1.c.youtube.com/CiILENy73wIaGQmgzEr8Wz0OoRMYESARFEgGUgZ2aWRlb3MM/0/0/0/video.3gp","type":"video/3gpp","medium":"video","expression":"full","duration":2,"yt$format":6}],"media$credit":[{"$t":"juliend2","role":"uploader","scheme":"urn:youtube","yt$display":"Julien
+        Desrosiers"}],"media$description":{"$t":"","type":"plain"},"media$keywords":{},"media$license":{"$t":"youtube","type":"text/html","href":"http://www.youtube.com/t/terms"},"media$player":{"url":"http://www.youtube.com/watch?v=oQ49W_xKzKA&feature=youtube_gdata_player"},"media$thumbnail":[{"url":"http://i.ytimg.com/vi/oQ49W_xKzKA/default.jpg","height":90,"width":120,"time":"00:00:01","yt$name":"default"},{"url":"http://i.ytimg.com/vi/oQ49W_xKzKA/mqdefault.jpg","height":180,"width":320,"yt$name":"mqdefault"},{"url":"http://i.ytimg.com/vi/oQ49W_xKzKA/hqdefault.jpg","height":360,"width":480,"yt$name":"hqdefault"},{"url":"http://i.ytimg.com/vi/oQ49W_xKzKA/sddefault.jpg","height":480,"width":640,"yt$name":"sddefault"},{"url":"http://i.ytimg.com/vi/oQ49W_xKzKA/1.jpg","height":90,"width":120,"time":"00:00:00.500","yt$name":"start"},{"url":"http://i.ytimg.com/vi/oQ49W_xKzKA/2.jpg","height":90,"width":120,"time":"00:00:01","yt$name":"middle"},{"url":"http://i.ytimg.com/vi/oQ49W_xKzKA/3.jpg","height":90,"width":120,"time":"00:00:01.500","yt$name":"end"}],"media$title":{"$t":"test3","type":"plain"},"yt$duration":{"seconds":"2"},"yt$uploaded":{"$t":"2011-01-05T21:24:39.000Z"},"yt$uploaderId":{"$t":"UCD3uCEQGGRDKDXONecXCx9g"},"yt$videoid":{"$t":"oQ49W_xKzKA"}},"yt$statistics":{"favoriteCount":"0","viewCount":"6"}}}'
+    http_version: 
+  recorded_at: Wed, 01 May 2013 13:04:30 GMT
+recorded_with: VCR 2.4.0

--- a/spec/lib/video_info/providers/vimeo_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_spec.rb
@@ -23,7 +23,7 @@ describe VideoInfo::Providers::Vimeo do
     its(:video_id)         { should eq '898029' }
     its(:url)              { should eq 'http://vimeo.com/898029' }
     its(:embed_url)        { should eq 'http://player.vimeo.com/video/898029' }
-    its(:embed_code)       { should eq '<iframe src="http://player.vimeo.com/video/898029?title=0&amp;byline=0&amp;portrait=0&amp;autoplay=0" frameborder="0"></iframe>' }
+    its(:embed_code)       { should eq '<iframe src="http://player.vimeo.com/video/898029?autoplay=0&byline=0&portrait=0&title=0" frameborder="0"></iframe>' }
     its(:title)            { should eq 'Cherry Bloom - King Of The Knife' }
     its(:description)      { should eq 'The first video from the upcoming album Secret Sounds, to download in-stores April 14. Checkout http://www.cherrybloom.net' }
     its(:keywords)         { should eq 'cherry bloom, secret sounds, king of the knife, rock, alternative' }
@@ -37,11 +37,17 @@ describe VideoInfo::Providers::Vimeo do
     its(:view_count)       { should be > 4000 }
   end
 
-  context "with video 898029 and iframe_attributes", :vcr do
-    subject { VideoInfo.get('http://www.vimeo.com/898029', :iframe_attributes => { :width => 800, :height => 600 }) }
+  context "with video 898029 and url_attributes", :vcr do
+    subject { VideoInfo.get('http://www.vimeo.com/898029') }
 
-    its(:embed_code) { should match(/width="800"/) }
-    its(:embed_code) { should match(/height="600"/) }
+    it { subject.embed_code(:url_attributes => { :autoplay => 1 }).should match(/autoplay=1/) }
+  end
+
+  context "with video 898029 and iframe_attributes", :vcr do
+    subject { VideoInfo.get('http://www.vimeo.com/898029') }
+
+    it { subject.embed_code(:iframe_attributes => { :width => 800, :height => 600 }).should match(/width="800"/) }
+    it { subject.embed_code(:iframe_attributes => { :width => 800, :height => 600 }).should match(/height="600"/) }
   end
 
   context "with video 898029 in /group/ url", :vcr do

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -45,6 +45,12 @@ describe VideoInfo::Providers::Youtube do
   context "with video oQ49W_xKzKA", :vcr do
     subject { VideoInfo.get('http://www.youtube.com/watch?v=oQ49W_xKzKA') }
 
+    it { subject.embed_code(:url_attributes => { :autoplay => 1 }).should match(/autoplay=1/) }
+  end
+
+  context "with video oQ49W_xKzKA", :vcr do
+    subject { VideoInfo.get('http://www.youtube.com/watch?v=oQ49W_xKzKA') }
+
     its(:provider) { should eq 'YouTube' }
     its(:video_id) { should eq 'oQ49W_xKzKA' }
   end
@@ -94,18 +100,18 @@ describe VideoInfo::Providers::Youtube do
   end
 
   context "with iframe attributes", :vcr do
-    subject { VideoInfo.get('http://www.youtube.com/watch?v=mZqGqE0D0n4', :iframe_attributes => { :width => 800, :height => 600 }) }
+    subject { VideoInfo.get('http://www.youtube.com/watch?v=mZqGqE0D0n4') }
 
-    its(:provider)   { should == 'YouTube' }
-    its(:embed_code) { should match(/width="800"/) }
-    its(:embed_code) { should match(/height="600"/) }
+    its(:provider) { should == 'YouTube' }
+    it { subject.embed_code(:iframe_attributes => { :width => 800, :height => 600 }).should match(/width="800"/) }
+    it { subject.embed_code(:iframe_attributes => { :width => 800, :height => 600 }).should match(/height="600"/) }
   end
 
   context "with arbitrary iframe_attributes", :vcr do
-    subject { VideoInfo.get('http://www.youtube.com/watch?v=mZqGqE0D0n4', :iframe_attributes => { "data-colorbox" => "true" } ) }
+    subject { VideoInfo.get('http://www.youtube.com/watch?v=mZqGqE0D0n4') }
 
     its(:provider)   { should == 'YouTube' }
-    its(:embed_code) { should match(/data-colorbox="true"/) }
+    it { subject.embed_code(:iframe_attributes => { :'data-colorbox' => true }).should match(/data-colorbox="true"/) }
   end
 
 end

--- a/video_info.gemspec
+++ b/video_info.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "video_info"
 
+  s.add_dependency 'addressable'
   s.add_dependency 'multi_json'
 
   s.add_development_dependency 'bundler'


### PR DESCRIPTION
I believe it makes more sense to have the #embed_code as a method on the Provider class.

This allows us to cache the video info from the provider's API, and then generate embed code with different iframe attributes as needed.

I have also added the possibility to specify additional :url_attributes via hash (for example :autoplay => 1) etc.

Would this make sense to be pulled in?
(I bumped the version to 1.3.3.)

Best, Tomas
