### PR TITLE
Add support for Vimeo Channels

### DIFF
--- a/lib/video_info/providers/vimeo.rb
+++ b/lib/video_info/providers/vimeo.rb
@@ -41,7 +41,7 @@ class VideoInfo
       end
 
       def _url_regex
-        /.*\.com\/(?:(?:groups\/[^\/]+\/videos\/)|(?:ondemand\/less\/)|(?:video\/))?([0-9]+).*$/
+        /.*\.com\/(?:(?:groups\/[^\/]+\/videos\/)|(?:ondemand|channels)(?:(?:\/less\/)|(?:\/\w*\/))|(?:video\/))?([0-9]+).*$/
       end
 
       def _api_base

--- a/spec/lib/video_info/providers/vimeo_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_spec.rb
@@ -15,6 +15,11 @@ describe VideoInfo::Providers::Vimeo do
       it { is_expected.to be_truthy }
     end
 
+    context "with Vimeo Channels url" do
+      let(:url) { 'https://vimeo.com/channels/any_channel/111431415' }
+      it { is_expected.to be_truthy }
+    end
+
     context "with vimeo album url" do
       let(:url) { 'http://vimeo.com/album/2755718' }
       it { is_expected.to be_falsey }
@@ -201,6 +206,13 @@ describe VideoInfo::Providers::Vimeo do
 
     its(:provider) { should eq 'Vimeo' }
     its(:video_id) { should eq '101677664' }
+  end
+
+  context "with video 111431415 in /channels/*/ url", :vcr do
+    subject { VideoInfo.new('https://vimeo.com/channels/some_channel1/111431415') }
+
+    its(:provider) { should eq 'Vimeo' }
+    its(:video_id) { should eq '111431415' }
   end
 
 end


### PR DESCRIPTION
Added support for URLs like:
http://vimeo.com/channels/[channel_name]/[video_id]

I need support for this while using [link_thumbnailer](https://github.com/gottfrois/link_thumbnailer) gem
which in turn uses this one
