### PR TITLE
Ability to disable individual providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ VideoInfo.new('http://www.youtube.com/watch?v=mZqGqE0D0n4').embed_code(iframe_at
 => '<iframe src="//www.youtube.com/embed/mZqGqE0D0n4?autoplay=1" frameborder="0" allowfullscreen="allowfullscreen"></iframe>'
 ```
 
+If you would like to disable certain providers, you can do so by modifying the class variable `disable_providers`:
+
+``` ruby
+VideoInfo.disable_providers = %w[YouTube] # disable YouTube
+VideoInfo.disable_providers = %w[Vimeo YouTube] # disable Vimeo and Youtube
+VideoInfo.disable_providers = [] # enable all providers
+```
+
+Note: `disable_providers` is case-insensitive. Attempting to use a disabled provider will raise a UrlError, just like attempting to use a
+non-video URL.
+
 Author
 ------
 

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -6,7 +6,7 @@ require 'net/http'
 class VideoInfo
   class UrlError < StandardError; end
   extend Forwardable
-  
+ 
   PROVIDERS = %w[
     Dailymotion Vkontakte Wistia
     Vimeo VimeoPlaylist
@@ -56,9 +56,10 @@ class VideoInfo
   def _select_provider(url, options)
     if provider_const = _providers_const.detect { |p| p.usable?(url) }
       const_provider = provider_const.new(url, options)
-      
-      if defined? const_provider.provider and const_provider.provider
-        if self.class.disable_providers.map { |p| p.downcase }.include? const_provider.provider.downcase
+
+      if defined? const_provider.provider && const_provider.provider
+        if self.class.disable_providers.map(&:downcase).include? const_provider.provider.downcase
+
           raise UrlError, "#{const_provider.provider} is disabled"
         end
       end

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -62,6 +62,7 @@ class VideoInfo
           raise UrlError, "#{video_info.provider} is disabled"
         end
       end
+
       video_info
     else
       raise UrlError, "Url is not usable by any Providers: #{url}"

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -57,7 +57,7 @@ class VideoInfo
     if provider_const = _providers_const.detect { |p| p.usable?(url) }
       const_provider = provider_const.new(url, options)
 
-      if defined? const_provider.provider && const_provider.provider
+      if defined? const_provider.provider and const_provider.provider
         if self.class.disable_providers.map(&:downcase).include? const_provider.provider.downcase
 
           raise UrlError, "#{const_provider.provider} is disabled"

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -61,7 +61,7 @@ class VideoInfo
     if provider_const = _providers_const.detect { |p| p.usable?(url) }
       const_provider = provider_const.new(url, options)
 
-      if defined?(const_provider.provider) and const_provider.provider
+      if defined?(const_provider.provider) && const_provider.provider
         ensure_enabled_provider(const_provider.provider)
       end
 

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -55,15 +55,15 @@ class VideoInfo
 
   def _select_provider(url, options)
     if provider_const = _providers_const.detect { |p| p.usable?(url) }
-      video_info = provider_const.new(url, options)
-     
-      if defined? video_info.provider and video_info.provider
-        if self.class.disable_providers.include? video_info.provider
-          raise UrlError, "#{video_info.provider} is disabled"
+      const_provider = provider_const.new(url, options)
+      
+      if defined? const_provider.provider and const_provider.provider
+        if self.class.disable_providers.include? const_provider.provider
+          raise UrlError, "#{const_provider.provider} is disabled"
         end
       end
 
-      video_info
+      const_provider
     else
       raise UrlError, "Url is not usable by any Providers: #{url}"
     end

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -58,7 +58,7 @@ class VideoInfo
       const_provider = provider_const.new(url, options)
       
       if defined? const_provider.provider and const_provider.provider
-        if self.class.disable_providers.include? const_provider.provider
+        if self.class.disable_providers.map { |p| p.downcase }.include? const_provider.provider.downcase
           raise UrlError, "#{const_provider.provider} is disabled"
         end
       end

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -57,11 +57,8 @@ class VideoInfo
     if provider_const = _providers_const.detect { |p| p.usable?(url) }
       const_provider = provider_const.new(url, options)
 
-      if defined? const_provider.provider and const_provider.provider
-        if self.class.disable_providers.map(&:downcase).include? const_provider.provider.downcase
-
-          raise UrlError, "#{const_provider.provider} is disabled"
-        end
+      if defined?(const_provider.provider) and const_provider.provider
+        ensure_enabled_provider(const_provider.provider)
       end
 
       const_provider
@@ -72,5 +69,11 @@ class VideoInfo
 
   def _providers_const
     PROVIDERS.map { |p| Providers.const_get(p) }
+  end
+
+  def ensure_enabled_provider(provider)
+    if self.class.disable_providers.map(&:downcase).include?(provider.downcase)
+      raise UrlError, "#{provider} is disabled"
+    end
   end
 end

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -51,6 +51,10 @@ class VideoInfo
     @@disable_providers = providers
   end
 
+  def self.disabled_provider?(provider)
+    disable_providers.map(&:downcase).include?(provider.downcase)
+  end
+
   private
 
   def _select_provider(url, options)
@@ -72,7 +76,7 @@ class VideoInfo
   end
 
   def ensure_enabled_provider(provider)
-    if self.class.disable_providers.map(&:downcase).include?(provider.downcase)
+    if self.class.disabled_provider?(provider)
       raise UrlError, "#{provider} is disabled"
     end
   end

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -6,7 +6,7 @@ require 'net/http'
 class VideoInfo
   class UrlError < StandardError; end
   extend Forwardable
- 
+
   PROVIDERS = %w[
     Dailymotion Vkontakte Wistia
     Vimeo VimeoPlaylist

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -26,15 +26,13 @@ describe VideoInfo do
   end
   
   describe ".disable_providers" do
-    let(:disabled_providers) { %w[ YouTube ] }
-    let(:url) { 'https://www.youtube.com/watch?v=mZqGqE0D0n4'}
+    let(:youtube_url) { 'https://www.youtube.com/watch?v=mZqGqE0D0n4'}
 
     it "does not attempt to use a provider marked as disabled" do
-      VideoInfo.disable_providers = disabled_providers
+      VideoInfo.disable_providers = %w[YouTube]
 
-      expect { VideoInfo.new(url) }.to raise_error(VideoInfo::UrlError)
+      expect { VideoInfo.new(youtube_url) }.to raise_error(VideoInfo::UrlError)
 
-      # cleanup
       VideoInfo.disable_providers = []
     end
   end

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -30,9 +30,10 @@ describe VideoInfo do
     let(:vimeo_url) { 'http://vimeo.com/86701482' }
 
     it "does not attempt to use a provider marked as disabled" do
-      VideoInfo.disable_providers = %w[YouTube]
+      VideoInfo.disable_providers = %w[YouTube Vimeo]
 
       expect { VideoInfo.new(youtube_url) }.to raise_error(VideoInfo::UrlError)
+      expect { VideoInfo.new(vimeo_url) }.to raise_error(VideoInfo::UrlError)
 
       VideoInfo.disable_providers = []
     end

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -24,7 +24,7 @@ describe VideoInfo do
       expect { VideoInfo.new(url, options) }.to raise_error(VideoInfo::UrlError)
     end
   end
-  
+
   describe ".disable_providers" do
     let(:youtube_url) { 'https://www.youtube.com/watch?v=mZqGqE0D0n4' }
     let(:vimeo_url) { 'http://vimeo.com/86701482' }
@@ -40,7 +40,7 @@ describe VideoInfo do
 
     it "is case insensitive" do
       VideoInfo.disable_providers = %w[youTUBe VIMEO]
-      
+
       expect { VideoInfo.new(youtube_url) }.to raise_error(VideoInfo::UrlError)
       expect { VideoInfo.new(vimeo_url) }.to raise_error(VideoInfo::UrlError)
 

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -24,6 +24,20 @@ describe VideoInfo do
       expect { VideoInfo.new(url, options) }.to raise_error(VideoInfo::UrlError)
     end
   end
+  
+  describe ".disable_providers" do
+    let(:disabled_providers) { %w[ YouTube ] }
+    let(:url) { 'https://www.youtube.com/watch?v=mZqGqE0D0n4'}
+
+    it "does not attempt to use a provider marked as disabled" do
+      VideoInfo.disable_providers = disabled_providers
+
+      expect { VideoInfo.new(url) }.to raise_error(VideoInfo::UrlError)
+
+      # cleanup
+      VideoInfo.disable_providers = []
+    end
+  end
 
   describe ".usable?" do
     let(:url) { 'url' }

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -27,11 +27,21 @@ describe VideoInfo do
   
   describe ".disable_providers" do
     let(:youtube_url) { 'https://www.youtube.com/watch?v=mZqGqE0D0n4'}
+    let(:vimeo_url) { 'http://vimeo.com/86701482' }
 
     it "does not attempt to use a provider marked as disabled" do
       VideoInfo.disable_providers = %w[YouTube]
 
       expect { VideoInfo.new(youtube_url) }.to raise_error(VideoInfo::UrlError)
+
+      VideoInfo.disable_providers = []
+    end
+
+    it "is case insensitive" do
+      VideoInfo.disable_providers = %w[youTUBe VIMEO]
+      
+      expect { VideoInfo.new(youtube_url) }.to raise_error(VideoInfo::UrlError)
+      expect { VideoInfo.new(vimeo_url) }.to raise_error(VideoInfo::UrlError)
 
       VideoInfo.disable_providers = []
     end

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -26,7 +26,7 @@ describe VideoInfo do
   end
   
   describe ".disable_providers" do
-    let(:youtube_url) { 'https://www.youtube.com/watch?v=mZqGqE0D0n4'}
+    let(:youtube_url) { 'https://www.youtube.com/watch?v=mZqGqE0D0n4' }
     let(:vimeo_url) { 'http://vimeo.com/86701482' }
 
     it "does not attempt to use a provider marked as disabled" do


### PR DESCRIPTION
As discussed in issue #66, I implemented the ability to disable individual providers. This is necessary to move forward with fixing Youtube support.

Documentation for this feature is in README.md, at the bottom of the Options section.

I implemented a few tests. Note that Travis should fail because of the Youtube API changes, but closer inspection should reveal that my changes did not break anything.

I also realize that my changes are a bit ugly, but this is the only way I could get it to function properly.