### PR TITLE
Youtube fixes (everything except '#available?')

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ video = VideoInfo.new("http://fast.wistia.com/embed/medias/pxonqr42is")
 # video.embed_url        => '//fast.wistia.net/embed/iframe/pxonqr42is'
 # video.embed_code       => "<iframe src='//fast.wistia.net/embed/iframe/pxonqr42is' frameborder='0'></iframe>"
 
+# Youtube recently updated their API to require an API key. To get an API key, [follow the instructions here.](https://developers.google.com/youtube/registering_an_application)
+
+VideoInfo.provider_api_keys = { youtube: 'YOUR_API_KEY' }
+
 video = VideoInfo.new("http://www.youtube.com/watch?v=mZqGqE0D0n4")
 # video.available?       => true
 # video.video_id         => 'mZqGqE0D0n4'

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ gem install video_info
 Usage
 -----
 
+## Note for YouTube usage!
+Youtube recently updated their API to require an API key. To get an API key, [follow the instructions here](https://developers.google.com/youtube/registering_an_application)
+
+To set the API key, do the following:
+``` ruby
+VideoInfo.provider_api_keys = { youtube: 'YOUR_API_KEY' }
+```
+
+
 ``` ruby
 video = VideoInfo.new('http://www.dailymotion.com/video/x7lni3')
 # video.available?       => true
@@ -61,10 +70,6 @@ video = VideoInfo.new("http://fast.wistia.com/embed/medias/pxonqr42is")
 # video.thumbnail_large  => 'https://embed-ssl.wistia.com/deliveries/0fccbdc60ade35723f79f1c002bc61b135b610fa.jpg?image_crop_resized=960x540'
 # video.embed_url        => '//fast.wistia.net/embed/iframe/pxonqr42is'
 # video.embed_code       => "<iframe src='//fast.wistia.net/embed/iframe/pxonqr42is' frameborder='0'></iframe>"
-
-# Youtube recently updated their API to require an API key. To get an API key, [follow the instructions here.](https://developers.google.com/youtube/registering_an_application)
-
-VideoInfo.provider_api_keys = { youtube: 'YOUR_API_KEY' }
 
 video = VideoInfo.new("http://www.youtube.com/watch?v=mZqGqE0D0n4")
 # video.available?       => true

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -47,8 +47,11 @@ class VideoInfo
     @@provider_api_keys
   end
 
-  def self.provider_api_keys=(keys)
-    @@provider_api_keys = keys
+  def self.provider_api_keys=(api_keys)
+    api_keys.keys.each do |key|
+      raise ArgumentError, "Key must be a symbol!" unless key.is_a?(Symbol)
+    end
+    @@provider_api_keys = api_keys
   end
 
   @@disable_providers = []

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -63,7 +63,6 @@ class VideoInfo
 
   def self.disabled_provider?(provider)
     disable_providers.map(&:downcase).include?(provider.downcase)
->>>>>>> master
   end
 
   private

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -40,6 +40,16 @@ class VideoInfo
   def ==(other)
     url == other.url && video_id == other.video_id
   end
+  
+  @@provider_api_keys = {}
+
+  def self.provider_api_keys
+    @@provider_api_keys
+  end
+
+  def self.provider_api_keys=(keys)
+    @@provider_api_keys = keys
+  end
 
   private
 

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -40,7 +40,7 @@ class VideoInfo
   def ==(other)
     url == other.url && video_id == other.video_id
   end
-  
+
   @@provider_api_keys = {}
 
   def self.provider_api_keys

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -49,7 +49,7 @@ class VideoInfo
 
   def self.provider_api_keys=(api_keys)
     api_keys.keys.each do |key|
-      raise ArgumentError, "Key must be a symbol!" unless key.is_a?(Symbol)
+      raise ArgumentError, 'Key must be a symbol!' unless key.is_a?(Symbol)
     end
     @@provider_api_keys = api_keys
   end

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -1,3 +1,4 @@
+require 'iso8601'
 class VideoInfo
   module Providers
     class Youtube < Provider
@@ -9,12 +10,24 @@ class VideoInfo
         'YouTube'
       end
 
-      def title
-        _video_entry['title']['$t']
+      def api_key
+        VideoInfo.providers_api_key[:youtube]
       end
 
-      %w[description keywords].each do |method|
-        define_method(method) { _video_media_group["media$#{method}"]['$t'] }
+      def title
+        _video_snippet['title']
+      end
+
+      # %w[description keywords].each do |method|
+      #   define_method(method) { _video_entry["media$#{method}"]['$t'] }
+      # end
+
+      def description
+        _video_snippet['description']
+      end
+
+      def keywords
+        _video_snippet['tags']
       end
 
       %w[width height].each do |method|
@@ -22,7 +35,7 @@ class VideoInfo
       end
 
       def duration
-        _video_media_group['yt$duration']['seconds'].to_i
+         ISO8601::Duration.new(_video_content_details['duration']).to_seconds.to_i
       end
 
       def embed_url
@@ -30,27 +43,23 @@ class VideoInfo
       end
 
       def date
-        Time.parse(_video_entry['published']['$t'], Time.now.utc)
+        Time.parse(_video_snippet['publishedAt'], Time.now.utc)
       end
 
       def thumbnail_small
-        _video_thumbnail(0)
+        _video_snippet['thumbnails']['default']['url']
       end
 
       def thumbnail_medium
-        _video_thumbnail(1)
+        _video_snippet['thumbnails']['medium']['url']
       end
 
       def thumbnail_large
-        _video_thumbnail(2)
+        _video_snippet['thumbnails']['high']['url']
       end
 
       def view_count
-        if _video_entry['yt$statistics']
-          _video_entry['yt$statistics']['viewCount'].to_i
-        else
-          0
-        end
+        _video_statistics['viewCount'].to_i rescue 0
       end
 
       private
@@ -60,15 +69,15 @@ class VideoInfo
       end
 
       def _api_base
-        "gdata.youtube.com"
+        "www.googleapis.com"
       end
 
       def _api_path
-        "/feeds/api/videos/#{video_id}?v=2&alt=json"
+        "/youtube/v3/videos?id=#{video_id}&part=snippet,statistics,contentDetails&fields=items(id,snippet,statistics,contentDetails)&key=#{api_key}"
       end
 
       def _api_url
-        "http://#{_api_base}#{_api_path}"
+        "https://#{_api_base}#{_api_path}"
       end
 
       def _default_iframe_attributes
@@ -79,13 +88,21 @@ class VideoInfo
         {}
       end
 
-      def _video_entry
-        data['entry']
+      def _video_snippet
+        data['items'][0]['snippet']
       end
 
-      def _video_media_group
-        data['entry']['media$group']
+      def _video_content_details
+        data['items'][0]['contentDetails']
       end
+
+      def _video_statistics
+        data['items'][0]['statistics']
+      end
+
+      # def _video_media_group
+      #   data['entry']['media$group']
+      # end
 
       def _video_thumbnail(id)
         _video_entry['media$group']['media$thumbnail'][id]['url']

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -66,7 +66,7 @@ class VideoInfo
       end
 
       def _api_base
-        "www.googleapis.com"
+        'www.googleapis.com'
       end
 
       def _api_path

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -97,10 +97,6 @@ class VideoInfo
         data['items'][0]['statistics']
       end
 
-      # def _video_media_group
-      #   data['entry']['media$group']
-      # end
-
       def _video_thumbnail(id)
         _video_entry['media$group']['media$thumbnail'][id]['url']
       end

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -31,7 +31,8 @@ class VideoInfo
       end
 
       def duration
-         ISO8601::Duration.new(_video_content_details['duration']).to_seconds.to_i
+        video_duration = _video_content_details['duration']
+        ISO8601::Duration.new(video_duration).to_seconds.to_i
       end
 
       def embed_url

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -11,7 +11,7 @@ class VideoInfo
       end
 
       def api_key
-        VideoInfo.providers_api_keys[:youtube]
+        VideoInfo.provider_api_keys[:youtube]
       end
 
       def title

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -61,6 +61,10 @@ class VideoInfo
 
       private
 
+      def available?
+        data['items'].size > 0 rescue false
+      end
+
       def _url_regex
         /(?:youtube(?:-nocookie)?\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/ ]{11})/i
       end

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -11,7 +11,7 @@ class VideoInfo
       end
 
       def api_key
-        VideoInfo.providers_api_key[:youtube]
+        VideoInfo.providers_api_keys[:youtube]
       end
 
       def title

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -18,10 +18,6 @@ class VideoInfo
         _video_snippet['title']
       end
 
-      # %w[description keywords].each do |method|
-      #   define_method(method) { _video_entry["media$#{method}"]['$t'] }
-      # end
-
       def description
         _video_snippet['description']
       end

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe VideoInfo::Providers::Youtube do
   before(:all) do
-    VideoInfo.provider_api_keys = { :youtube => 'AIzaSyA6PYwSr1EnLFUFy1cZDk3Ifb0rxeJaeZ0' }
+    VideoInfo.provider_api_keys = { youtube: 'AIzaSyA6PYwSr1EnLFUFy1cZDk3Ifb0rxeJaeZ0' }
   end
 
   describe ".usable?" do

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -123,17 +123,17 @@ describe VideoInfo::Providers::Youtube do
 
     describe '#thumbnail_small' do
       subject { super().thumbnail_small }
-      it { is_expected.to eq 'http://i.ytimg.com/vi/mZqGqE0D0n4/default.jpg' }
+      it { is_expected.to eq 'https://i.ytimg.com/vi/mZqGqE0D0n4/default.jpg' }
     end
 
     describe '#thumbnail_medium' do
       subject { super().thumbnail_medium }
-      it { is_expected.to eq 'http://i.ytimg.com/vi/mZqGqE0D0n4/mqdefault.jpg' }
+      it { is_expected.to eq 'https://i.ytimg.com/vi/mZqGqE0D0n4/mqdefault.jpg' }
     end
 
     describe '#thumbnail_large' do
       subject { super().thumbnail_large }
-      it { is_expected.to eq 'http://i.ytimg.com/vi/mZqGqE0D0n4/hqdefault.jpg' }
+      it { is_expected.to eq 'https://i.ytimg.com/vi/mZqGqE0D0n4/hqdefault.jpg' }
     end
 
     describe '#view_count' do

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe VideoInfo::Providers::Youtube do
+  before(:all) do
+    VideoInfo.provider_api_keys = { youtube: 'AIzaSyA6PYwSr1EnLFUFy1cZDk3Ifb0rxeJaeZ0' }
+  end
 
   describe ".usable?" do
     subject { VideoInfo::Providers::Youtube.usable?(url) }

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe VideoInfo::Providers::Youtube do
   before(:all) do
-    VideoInfo.provider_api_keys = { youtube: 'AIzaSyA6PYwSr1EnLFUFy1cZDk3Ifb0rxeJaeZ0' }
+    VideoInfo.provider_api_keys = { :youtube => 'AIzaSyA6PYwSr1EnLFUFy1cZDk3Ifb0rxeJaeZ0' }
   end
 
   describe ".usable?" do

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -70,6 +70,13 @@ describe VideoInfo do
     end
   end
 
+  describe ".provider_api_keys" do
+    it "raises an error if key isn't a symbol" do
+      expect { VideoInfo.provider_api_keys = { "Youtube" => "key" } }.to raise_error(ArgumentError)
+      expect { VideoInfo.provider_api_keys = { youtube: "key" } }.to_not raise_error
+    end
+  end
+
   describe "#==" do
     let(:vi_a) { VideoInfo.new('http://www.youtube.com/watch?v=AT_5xOGh6Ko') }
     let(:vi_b) { VideoInfo.new('http://www.youtube.com/watch?v=AT_5xOGh6Ko') }

--- a/video_info.gemspec
+++ b/video_info.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'addressable'
   s.add_dependency 'multi_json'
   s.add_dependency 'htmlentities'
+  s.add_dependency 'iso8601'
 
   s.add_development_dependency 'bundler', '>= 1.3.5'
   s.add_development_dependency 'rake'


### PR DESCRIPTION
I merged in the changes from @bonf's repository linked in #66. All I did was remove some commented out code, fix a few specs, and implemented VideoInfo.provider_api_keys hash.

All of the Youtube specs pass except '#available?', which, as far as I can tell, has something to do with SSL (thanks for that, Google...). I messed around with it for half an hour but couldn't get it to pass. 

Also, I didn't touch YoutubePlaylist yet. I think I'll be able to get to that sometime in the next few days if nobody else does.

This should merge cleanly with my other PR, #67 

Also, I left my API key in youtube_spec.rb 
You should generate your own, set it as an environment variable in Travis, and access it with ENV or something.