### PR TITLE
fixed Vkontakte#available? returning true for private videos

### DIFF
--- a/lib/video_info/providers/vkontakte.rb
+++ b/lib/video_info/providers/vkontakte.rb
@@ -104,7 +104,7 @@ class VideoInfo
         ).encode(
           'UTF-8', undef: :replace
         )
-        !!title.index('Ошибка')
+        title.index('Error | VK')
       end
 
       def _get_response_code(response)

--- a/lib/video_info/providers/vkontakte.rb
+++ b/lib/video_info/providers/vkontakte.rb
@@ -104,7 +104,7 @@ class VideoInfo
         ).encode(
           'UTF-8', undef: :replace
         )
-        title.index('Error | VK')
+        !!title.index('Error | VK')
       end
 
       def _get_response_code(response)


### PR DESCRIPTION
I don't use Vkontakte, but it looks like a change broke `_error_found?` since it was returning false for every spec.

I changed it so that it just checks if the title is 'Error | VK'.