### PR TITLE
pinned multi_json version to 1.11

### DIFF
--- a/video_info.gemspec
+++ b/video_info.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_dependency 'addressable'
-  s.add_dependency 'multi_json'
+  s.add_dependency 'multi_json', '~> 1.11'
   s.add_dependency 'htmlentities'
   s.add_dependency 'iso8601'
 


### PR DESCRIPTION
Older versions of multi_json don't work with this gem. This was discussed in issue #66 