### PR TITLE
Youtube Scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,13 @@ Usage
 -----
 
 ## Note for YouTube usage!
-Youtube recently updated their API to require an API key. To get an API key, [follow the instructions here](https://developers.google.com/youtube/registering_an_application)
+Youtube recently updated their API to require an API key. 
+
+To get around this, a scraper was implemented. However, the scraper can only get the date the video was posted, while the API is able to get the date and the exact time the video was posted.
+
+You may also wish to use the API to protect against potential HTML changes that could break the scraper.
+
+To get an API key, [follow the instructions here](https://developers.google.com/youtube/registering_an_application)
 
 To set the API key, do the following:
 ``` ruby

--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -1,11 +1,16 @@
 require 'iso8601'
 require_relative 'youtube_api'
+require_relative 'youtube_scraper'
 
 class VideoInfo
   module Providers
     class Youtube < Provider
       def initialize(url, options = {})
-        extend YoutubeAPI
+        if VideoInfo.provider_api_keys[:youtube].nil?
+          extend YoutubeScraper
+        else
+          extend YoutubeAPI
+        end
 
         super(url, options)
       end

--- a/lib/video_info/providers/youtube_api.rb
+++ b/lib/video_info/providers/youtube_api.rb
@@ -1,70 +1,72 @@
 class VideoInfo
-  module YoutubeAPI
-    def api_key
-      VideoInfo.provider_api_keys[:youtube]
-    end
+  module Providers
+    module YoutubeAPI
+      def api_key
+        VideoInfo.provider_api_keys[:youtube]
+      end
 
-    def title
-      _video_snippet['title']
-    end
+      def title
+        _video_snippet['title']
+      end
 
-    def description
-      _video_snippet['description']
-    end
+      def description
+        _video_snippet['description']
+      end
 
-    def keywords
-      _video_snippet['tags']
-    end
+      def keywords
+        _video_snippet['tags']
+      end
 
-    def duration
-      video_duration = _video_content_details['duration'] || 0
-      ISO8601::Duration.new(video_duration).to_seconds.to_i
-    end
+      def duration
+        video_duration = _video_content_details['duration'] || 0
+        ISO8601::Duration.new(video_duration).to_seconds.to_i
+      end
 
-    def date
-      return unless published_at = _video_snippet['publishedAt']
-      Time.parse(published_at, Time.now.utc)
-    end
+      def date
+        return unless published_at = _video_snippet['publishedAt']
+        Time.parse(published_at, Time.now.utc)
+      end
 
-    def view_count
-      _video_statistics['viewCount'].to_i rescue 0
-    end
+      def view_count
+        _video_statistics['viewCount'].to_i rescue 0
+      end
 
-    private
+      private
 
-    def available?
-      data['items'].size > 0 rescue false
-    end
+      def available?
+        data['items'].size > 0 rescue false
+      end
 
-    def _api_base
-      'www.googleapis.com'
-    end
+      def _api_base
+        'www.googleapis.com'
+      end
 
-    def _api_path
-      "/youtube/v3/videos?id=#{video_id}&part=snippet,statistics,contentDetails&fields=items(id,snippet,statistics,contentDetails)&key=#{api_key}"
-    end
+      def _api_path
+        "/youtube/v3/videos?id=#{video_id}&part=snippet,statistics,contentDetails&fields=items(id,snippet,statistics,contentDetails)&key=#{api_key}"
+      end
 
-    def _api_url
-      "https://#{_api_base}#{_api_path}"
-    end
+      def _api_url
+        "https://#{_api_base}#{_api_path}"
+      end
 
-    def _video_snippet
-      return {} unless available?
-      data['items'][0]['snippet']
-    end
+      def _video_snippet
+        return {} unless available?
+        data['items'][0]['snippet']
+      end
 
-    def _video_content_details
-      return {} unless available?
-      data['items'][0]['contentDetails']
-    end
+      def _video_content_details
+        return {} unless available?
+        data['items'][0]['contentDetails']
+      end
 
-    def _video_statistics
-      return {} unless available?
-      data['items'][0]['statistics']
-    end
+      def _video_statistics
+        return {} unless available?
+        data['items'][0]['statistics']
+      end
 
-    def _video_thumbnail(id)
-      _video_entry['media$group']['media$thumbnail'][id]['url']
+      def _video_thumbnail(id)
+        _video_entry['media$group']['media$thumbnail'][id]['url']
+      end
     end
   end
 end

--- a/lib/video_info/providers/youtube_api.rb
+++ b/lib/video_info/providers/youtube_api.rb
@@ -1,0 +1,70 @@
+class VideoInfo
+  module YoutubeAPI
+    def api_key
+      VideoInfo.provider_api_keys[:youtube]
+    end
+
+    def title
+      _video_snippet['title']
+    end
+
+    def description
+      _video_snippet['description']
+    end
+
+    def keywords
+      _video_snippet['tags']
+    end
+
+    def duration
+      video_duration = _video_content_details['duration'] || 0
+      ISO8601::Duration.new(video_duration).to_seconds.to_i
+    end
+
+    def date
+      return unless published_at = _video_snippet['publishedAt']
+      Time.parse(published_at, Time.now.utc)
+    end
+
+    def view_count
+      _video_statistics['viewCount'].to_i rescue 0
+    end
+
+    private
+
+    def available?
+      data['items'].size > 0 rescue false
+    end
+
+    def _api_base
+      'www.googleapis.com'
+    end
+
+    def _api_path
+      "/youtube/v3/videos?id=#{video_id}&part=snippet,statistics,contentDetails&fields=items(id,snippet,statistics,contentDetails)&key=#{api_key}"
+    end
+
+    def _api_url
+      "https://#{_api_base}#{_api_path}"
+    end
+
+    def _video_snippet
+      return {} unless available?
+      data['items'][0]['snippet']
+    end
+
+    def _video_content_details
+      return {} unless available?
+      data['items'][0]['contentDetails']
+    end
+
+    def _video_statistics
+      return {} unless available?
+      data['items'][0]['statistics']
+    end
+
+    def _video_thumbnail(id)
+      _video_entry['media$group']['media$thumbnail'][id]['url']
+    end
+  end
+end

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -15,8 +15,6 @@ class VideoInfo
           end
 
           Time.parse(date_published_node.attr('content').value)
-        else
-          nil
         end
       end
 
@@ -29,8 +27,6 @@ class VideoInfo
           end
 
           description_node.attr('content').value
-        else
-          nil
         end
       end
 
@@ -61,8 +57,6 @@ class VideoInfo
           end
 
           keywords_node.attr('content').value
-        else
-          nil
         end
       end
 
@@ -75,21 +69,19 @@ class VideoInfo
           end
 
           title_node.attr('content').value
-        else
-          nil
         end
       end
 
       def thumbnail_small
-        return "https://i.ytimg.com/vi/#{video_id}/default.jpg"
+        "https://i.ytimg.com/vi/#{video_id}/default.jpg"
       end
 
       def thumbnail_medium
-        return "https://i.ytimg.com/vi/#{video_id}/mqdefault.jpg"
+        "https://i.ytimg.com/vi/#{video_id}/mqdefault.jpg"
       end
 
       def thumbnail_large
-        return "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg"
+        "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg"
       end
 
       def view_count

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -58,6 +58,10 @@ class VideoInfo
         return "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg"
       end
 
+      def view_count
+        data.css('div.watch-view-count').text.gsub(',', '').to_i
+      end
+
       private
 
       def available?

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -5,23 +5,45 @@ class VideoInfo
   module Providers
     module YoutubeScraper
       def description
-        meta_nodes = data.css('meta')
+        if available?
+          meta_nodes = data.css('meta')
 
-        description_node = meta_nodes.detect do |m|
-          m.attr('name').value == 'description'
+          description_node = meta_nodes.detect do |m|
+            m.attr('name').value == 'description'
+          end
+
+          description_node.attr('content').value
+        else
+          nil
         end
+      end
 
-        description_node.attr('content').value
+      def keywords
+        if available?
+          meta_nodes = data.css('meta')
+
+          description_node = meta_nodes.detect do |m|
+            m.attr('name').value == 'keywords'
+          end
+
+          description_node.attr('content').value
+        else
+          nil
+        end
       end
 
       def title
-        meta_nodes = data.css('meta')
+        if available?
+          meta_nodes = data.css('meta')
 
-        title_node = meta_nodes.detect do |m|
-          m.attr('name').value == 'title'
+          title_node = meta_nodes.detect do |m|
+            m.attr('name').value == 'title'
+          end
+
+          title_node.attr('content').value
+        else
+          nil
         end
-
-        title_node.attr('content').value
       end
 
       def thumbnail_small
@@ -39,7 +61,7 @@ class VideoInfo
       private
 
       def available?
-        !data.css('div#page').attr('class')[0].value.include?('oops-content')
+        data.css('div#unavailable-submessage').text.strip.empty?
       end
 
       def _set_data_from_api(api_url = _api_url)

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -43,25 +43,15 @@ class VideoInfo
       end
 
       def keywords
-        if available?
-          keywords_node = meta_nodes.detect do |m|
-            m.attr('name').value == 'keywords'
-          end
+        value = meta_node_value('keywords')
 
-          keywords_node.attr('content').value.split(', ')
+        if value
+          value.split(', ')
         end
       end
 
       def title
-        if available?
-          meta_nodes = data.css('meta')
-
-          title_node = meta_nodes.detect do |m|
-            m.attr('name').value == 'title'
-          end
-
-          title_node.attr('content').value
-        end
+        meta_node_value('title')
       end
 
       def thumbnail_small
@@ -80,11 +70,19 @@ class VideoInfo
         data.css('div.watch-view-count').text.gsub(',', '').to_i
       end
 
+      private
+
       def meta_nodes
         @meta_nodes ||= data.css('meta')
       end
 
-      private
+      def meta_node_value(name)
+        if available?
+          node = meta_nodes.detect { |n| n.attr('name').value == name }
+
+          node.attr('content').value
+        end
+      end
 
       def available?
         data.css('div#unavailable-submessage').text.strip.empty?

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -1,0 +1,53 @@
+require 'oga'
+require 'open-uri'
+
+class VideoInfo
+  module YoutubeScraper
+    def description
+      meta_nodes = data.css('meta')
+
+      description_node = meta_nodes.detect do |m|
+        m.attr('name').value == 'description'
+      end
+
+      description_node.attr('content').value
+    end
+
+    def title
+      meta_nodes = data.css('meta')
+
+      title_node = meta_nodes.detect do |m|
+        m.attr('name').value == 'title'
+      end
+
+      title_node.attr('content').value
+    end
+
+    def thumbnail_small
+      return "https://i.ytimg.com/vi/#{video_id}/default.jpg"
+    end
+
+    def thumbnail_medium
+      return "https://i.ytimg.com/vi/#{video_id}/mqdefault.jpg"
+    end
+
+    def thumbnail_large
+      return "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg"
+    end
+
+    private
+
+
+    def available?
+      !data.css('div#page').attr('class')[0].value.include?('oops-content')
+    end
+
+    def _set_data_from_api(api_url = _api_url)
+      Oga.parse_html(open(api_url, :allow_redirections => :safe))
+    end
+
+    def _api_url
+      @url
+    end
+  end
+end

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -56,7 +56,7 @@ class VideoInfo
             m.attr('name').value == 'keywords'
           end
 
-          keywords_node.attr('content').value
+          keywords_node.attr('content').value.split(', ')
         end
       end
 

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -17,13 +17,7 @@ class VideoInfo
       end
 
       def description
-        if available?
-          description_node = meta_nodes.detect do |m|
-            m.attr('name').value == 'description'
-          end
-
-          description_node.attr('content').value
-        end
+        meta_node_value('description')
       end
 
       def duration
@@ -45,9 +39,7 @@ class VideoInfo
       def keywords
         value = meta_node_value('keywords')
 
-        if value
-          value.split(', ')
-        end
+        value.split(', ') unless !value
       end
 
       def title

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -81,7 +81,7 @@ class VideoInfo
       end
 
       def _set_data_from_api(api_url = _api_url)
-        Oga.parse_html(open(api_url, allow_redirections: :safe))
+        Oga.parse_html(open(api_url, allow_redirections: :safe).read)
       end
 
       def _api_url

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -5,15 +5,9 @@ class VideoInfo
   module Providers
     module YoutubeScraper
       def date
-        if available?
-          date_published_node = meta_nodes.detect do |m|
-            itemprop_attr = m.attr('itemprop')
+        date = itemprop_node_value('datePublished')
 
-            itemprop_attr.value == 'datePublished' unless !itemprop_attr
-          end
-
-          Time.parse(date_published_node.attr('content').value)
-        end
+        Time.parse(date) unless !date
       end
 
       def description
@@ -21,15 +15,9 @@ class VideoInfo
       end
 
       def duration
-        if available?
-          duration_node = meta_nodes.detect do |m|
-            itemprop_attr = m.attr('itemprop')
+        duration = itemprop_node_value('duration')
 
-            itemprop_attr.value == 'duration' unless !itemprop_attr
-          end
-
-          duration = duration_node.attr('content').value
-
+        if duration
           ISO8601::Duration.new(duration).to_seconds.to_i
         else
           0
@@ -71,6 +59,18 @@ class VideoInfo
       def meta_node_value(name)
         if available?
           node = meta_nodes.detect { |n| n.attr('name').value == name }
+
+          node.attr('content').value
+        end
+      end
+
+      def itemprop_node_value(name)
+        if available?
+          node = meta_nodes.detect do |m|
+            itemprop_attr = m.attr('itemprop')
+
+            itemprop_attr.value == name unless !itemprop_attr
+          end
 
           node.attr('content').value
         end

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -95,7 +95,7 @@ class VideoInfo
       end
 
       def _set_data_from_api(api_url = _api_url)
-        Oga.parse_html(open(api_url, :allow_redirections => :safe))
+        Oga.parse_html(open(api_url, allow_redirections: :safe))
       end
 
       def _api_url

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -4,6 +4,18 @@ require 'open-uri'
 class VideoInfo
   module Providers
     module YoutubeScraper
+      def date
+        meta_nodes = data.css('meta')
+
+        date_published_node = meta_nodes.detect do |m|
+          itemprop_attr = m.attr('itemprop')
+
+          itemprop_attr.value == 'datePublished' unless !itemprop_attr
+        end
+
+        Time.parse(date_published_node.attr('content').value)
+      end
+
       def description
         if available?
           meta_nodes = data.css('meta')

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -5,15 +5,19 @@ class VideoInfo
   module Providers
     module YoutubeScraper
       def date
-        meta_nodes = data.css('meta')
+        if available?
+          meta_nodes = data.css('meta')
 
-        date_published_node = meta_nodes.detect do |m|
-          itemprop_attr = m.attr('itemprop')
+          date_published_node = meta_nodes.detect do |m|
+            itemprop_attr = m.attr('itemprop')
 
-          itemprop_attr.value == 'datePublished' unless !itemprop_attr
+            itemprop_attr.value == 'datePublished' unless !itemprop_attr
+          end
+
+          Time.parse(date_published_node.attr('content').value)
+        else
+          nil
         end
-
-        Time.parse(date_published_node.attr('content').value)
       end
 
       def description
@@ -30,15 +34,31 @@ class VideoInfo
         end
       end
 
+      def duration
+        if available?
+          meta_nodes = data.css('meta')
+
+          duration_node = meta_nodes.detect do |m|
+            itemprop_attr = m.attr('itemprop')
+
+            itemprop_attr.value == 'duration' unless !itemprop_attr
+          end
+
+          duration_node.attr('content').value.to_i
+        else
+          0
+        end
+      end
+
       def keywords
         if available?
           meta_nodes = data.css('meta')
 
-          description_node = meta_nodes.detect do |m|
+          keywords_node = meta_nodes.detect do |m|
             m.attr('name').value == 'keywords'
           end
 
-          description_node.attr('content').value
+          keywords_node.attr('content').value
         else
           nil
         end

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -44,7 +44,9 @@ class VideoInfo
             itemprop_attr.value == 'duration' unless !itemprop_attr
           end
 
-          duration_node.attr('content').value.to_i
+          duration = duration_node.attr('content').value
+
+          ISO8601::Duration.new(duration).to_seconds.to_i
         else
           0
         end

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -2,52 +2,53 @@ require 'oga'
 require 'open-uri'
 
 class VideoInfo
-  module YoutubeScraper
-    def description
-      meta_nodes = data.css('meta')
+  module Providers
+    module YoutubeScraper
+      def description
+        meta_nodes = data.css('meta')
 
-      description_node = meta_nodes.detect do |m|
-        m.attr('name').value == 'description'
+        description_node = meta_nodes.detect do |m|
+          m.attr('name').value == 'description'
+        end
+
+        description_node.attr('content').value
       end
 
-      description_node.attr('content').value
-    end
+      def title
+        meta_nodes = data.css('meta')
 
-    def title
-      meta_nodes = data.css('meta')
+        title_node = meta_nodes.detect do |m|
+          m.attr('name').value == 'title'
+        end
 
-      title_node = meta_nodes.detect do |m|
-        m.attr('name').value == 'title'
+        title_node.attr('content').value
       end
 
-      title_node.attr('content').value
-    end
+      def thumbnail_small
+        return "https://i.ytimg.com/vi/#{video_id}/default.jpg"
+      end
 
-    def thumbnail_small
-      return "https://i.ytimg.com/vi/#{video_id}/default.jpg"
-    end
+      def thumbnail_medium
+        return "https://i.ytimg.com/vi/#{video_id}/mqdefault.jpg"
+      end
 
-    def thumbnail_medium
-      return "https://i.ytimg.com/vi/#{video_id}/mqdefault.jpg"
-    end
+      def thumbnail_large
+        return "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg"
+      end
 
-    def thumbnail_large
-      return "https://i.ytimg.com/vi/#{video_id}/hqdefault.jpg"
-    end
+      private
 
-    private
+      def available?
+        !data.css('div#page').attr('class')[0].value.include?('oops-content')
+      end
 
+      def _set_data_from_api(api_url = _api_url)
+        Oga.parse_html(open(api_url, :allow_redirections => :safe))
+      end
 
-    def available?
-      !data.css('div#page').attr('class')[0].value.include?('oops-content')
-    end
-
-    def _set_data_from_api(api_url = _api_url)
-      Oga.parse_html(open(api_url, :allow_redirections => :safe))
-    end
-
-    def _api_url
-      @url
+      def _api_url
+        @url
+      end
     end
   end
 end

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -6,8 +6,6 @@ class VideoInfo
     module YoutubeScraper
       def date
         if available?
-          meta_nodes = data.css('meta')
-
           date_published_node = meta_nodes.detect do |m|
             itemprop_attr = m.attr('itemprop')
 
@@ -20,8 +18,6 @@ class VideoInfo
 
       def description
         if available?
-          meta_nodes = data.css('meta')
-
           description_node = meta_nodes.detect do |m|
             m.attr('name').value == 'description'
           end
@@ -32,8 +28,6 @@ class VideoInfo
 
       def duration
         if available?
-          meta_nodes = data.css('meta')
-
           duration_node = meta_nodes.detect do |m|
             itemprop_attr = m.attr('itemprop')
 
@@ -50,8 +44,6 @@ class VideoInfo
 
       def keywords
         if available?
-          meta_nodes = data.css('meta')
-
           keywords_node = meta_nodes.detect do |m|
             m.attr('name').value == 'keywords'
           end
@@ -86,6 +78,10 @@ class VideoInfo
 
       def view_count
         data.css('div.watch-view-count').text.gsub(',', '').to_i
+      end
+
+      def meta_nodes
+        @meta_nodes ||= data.css('meta')
       end
 
       private

--- a/lib/video_info/providers/youtubeplaylist.rb
+++ b/lib/video_info/providers/youtubeplaylist.rb
@@ -29,6 +29,10 @@ class VideoInfo
         nil
       end
 
+      def keywords
+        nil
+      end
+
       def view_count
         nil
       end

--- a/lib/video_info/providers/youtubeplaylist.rb
+++ b/lib/video_info/providers/youtubeplaylist.rb
@@ -21,6 +21,18 @@ class VideoInfo
         url =~ /((youtube\.com)\/playlist)|((youtube\.com)\/embed\/videoseries)/
       end
 
+      def date
+        nil
+      end
+
+      def duration
+        nil
+      end
+
+      def view_count
+        nil
+      end
+
       def embed_url
         "//www.youtube.com/embed/videoseries?list=#{playlist_id}"
       end

--- a/lib/video_info/providers/youtubeplaylist.rb
+++ b/lib/video_info/providers/youtubeplaylist.rb
@@ -8,13 +8,13 @@ class VideoInfo
       attr_accessor :playlist_items_data
 
       def initialize(url, options = {})
+        super(url, options)
+
         if VideoInfo.provider_api_keys[:youtube].nil?
           extend YoutubePlaylistScraper
         else
           extend YoutubePlaylistAPI
         end
-
-        super(url, options)
       end
 
       def self.usable?(url)

--- a/lib/video_info/providers/youtubeplaylist_api.rb
+++ b/lib/video_info/providers/youtubeplaylist_api.rb
@@ -56,8 +56,8 @@ class VideoInfo
 
     private
 
-    def available?
-      !data.css('div#page').attr('class')[0].value.include?('oops-content')
-    end
+    #def available?
+    #  !data.css('div#page').attr('class')[0].value.include?('oops-content')
+    #end
   end
 end

--- a/lib/video_info/providers/youtubeplaylist_api.rb
+++ b/lib/video_info/providers/youtubeplaylist_api.rb
@@ -4,6 +4,10 @@ class VideoInfo
       data['items'][0]['snippet']['description']
     end
 
+    def date
+      nil
+    end
+
     def duration
       nil
     end
@@ -12,6 +16,10 @@ class VideoInfo
       _playlist_video_ids.map do |entry_id|
         VideoInfo.new("http://www.youtube.com/watch?v=#{entry_id}")
       end
+    end
+
+    def view_count
+      nil
     end
 
     private

--- a/lib/video_info/providers/youtubeplaylist_api.rb
+++ b/lib/video_info/providers/youtubeplaylist_api.rb
@@ -4,6 +4,10 @@ class VideoInfo
       data['items'][0]['snippet']['description']
     end
 
+    def duration
+      nil
+    end
+
     def videos
       _playlist_video_ids.map do |entry_id|
         VideoInfo.new("http://www.youtube.com/watch?v=#{entry_id}")

--- a/lib/video_info/providers/youtubeplaylist_api.rb
+++ b/lib/video_info/providers/youtubeplaylist_api.rb
@@ -41,5 +41,11 @@ class VideoInfo
         item['snippet']['resourceId']['videoId']
       end
     end
+
+    private
+
+    def available?
+      !data.css('div#page').attr('class')[0].value.include?('oops-content')
+    end
   end
 end

--- a/lib/video_info/providers/youtubeplaylist_api.rb
+++ b/lib/video_info/providers/youtubeplaylist_api.rb
@@ -53,11 +53,5 @@ class VideoInfo
         item['snippet']['resourceId']['videoId']
       end
     end
-
-    private
-
-    #def available?
-    #  !data.css('div#page').attr('class')[0].value.include?('oops-content')
-    #end
   end
 end

--- a/lib/video_info/providers/youtubeplaylist_scraper.rb
+++ b/lib/video_info/providers/youtubeplaylist_scraper.rb
@@ -5,26 +5,6 @@ require 'open_uri_redirections'
 class VideoInfo
   module Providers
     module YoutubePlaylistScraper
-      def description
-        meta_nodes = data.css('meta')
-
-        description_node = meta_nodes.detect do |m|
-          m.attr('name').value == 'description'
-        end
-
-        description_node.attr('content').value
-      end
-
-      def title
-        meta_nodes = data.css('meta')
-
-        title_node = meta_nodes.detect do |m|
-          m.attr('name').value == 'title'
-        end
-
-        title_node.attr('content').value
-      end
-
       def videos
         raise(NotImplementedError, 'To access videos, you must provide an API key to VideoInfo.provider_api_keys')
       end
@@ -39,20 +19,6 @@ class VideoInfo
 
       def thumbnail_large
         thumbnail_medium.sub('mqdefault.jpg', 'hqdefault.jpg')
-      end
-
-      private
-
-      def available?
-        !data.css('div#page').attr('class')[0].value.include?('oops-content')
-      end
-
-      def _set_data_from_api(api_url = _api_url)
-        Oga.parse_html(open(api_url, :allow_redirections => :safe))
-      end
-
-      def _api_url
-        @url
       end
     end
   end

--- a/lib/video_info/providers/youtubeplaylist_scraper.rb
+++ b/lib/video_info/providers/youtubeplaylist_scraper.rb
@@ -20,6 +20,12 @@ class VideoInfo
       def thumbnail_large
         thumbnail_medium.sub('mqdefault.jpg', 'hqdefault.jpg')
       end
+
+      private
+
+      def available?
+        !data.css('div#page').attr('class')[0].value.include?('oops-content')
+      end
     end
   end
 end

--- a/lib/video_info/providers/youtubeplaylist_scraper.rb
+++ b/lib/video_info/providers/youtubeplaylist_scraper.rb
@@ -5,8 +5,20 @@ require 'open_uri_redirections'
 class VideoInfo
   module Providers
     module YoutubePlaylistScraper
+      def date
+        nil
+      end
+
+      def duration
+        nil
+      end
+
       def videos
         raise(NotImplementedError, 'To access videos, you must provide an API key to VideoInfo.provider_api_keys')
+      end
+
+      def view_count
+        nil
       end
 
       def thumbnail_small

--- a/lib/video_info/providers/youtubeplaylist_scraper.rb
+++ b/lib/video_info/providers/youtubeplaylist_scraper.rb
@@ -13,6 +13,10 @@ class VideoInfo
         nil
       end
 
+      def keywords
+        nil
+      end
+
       def videos
         raise(NotImplementedError, 'To access videos, you must provide an API key to VideoInfo.provider_api_keys')
       end

--- a/spec/lib/video_info/providers/youtube_api_spec.rb
+++ b/spec/lib/video_info/providers/youtube_api_spec.rb
@@ -168,7 +168,7 @@ describe VideoInfo::Providers::Youtube do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to be_nil }
+      it { is_expected.to be ['cherry' 'bloom' 'king' 'of' 'the' 'knife' 'guitar' 'drum' 'clip' 'rock' 'alternative' 'tremplin' 'Paris-Forum'] }
     end
 
     describe '#duration' do

--- a/spec/lib/video_info/providers/youtube_api_spec.rb
+++ b/spec/lib/video_info/providers/youtube_api_spec.rb
@@ -123,7 +123,7 @@ describe VideoInfo::Providers::Youtube do
 
       describe '#available?' do
         subject { super().available? }
-        it { is_expected.to be_falsey }
+        it { is_expected.to be_true }
       end
     end
   end

--- a/spec/lib/video_info/providers/youtube_api_spec.rb
+++ b/spec/lib/video_info/providers/youtube_api_spec.rb
@@ -123,7 +123,7 @@ describe VideoInfo::Providers::Youtube do
 
       describe '#available?' do
         subject { super().available? }
-        it { is_expected.to be_true }
+        it { is_expected.to be_truthy }
       end
     end
   end

--- a/spec/lib/video_info/providers/youtube_api_spec.rb
+++ b/spec/lib/video_info/providers/youtube_api_spec.rb
@@ -168,7 +168,7 @@ describe VideoInfo::Providers::Youtube do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to be ['cherry' 'bloom' 'king' 'of' 'the' 'knife' 'guitar' 'drum' 'clip' 'rock' 'alternative' 'tremplin' 'Paris-Forum'] }
+      it { is_expected.to eq %w(cherry bloom king of the knife guitar drum clip rock alternative tremplin Paris-Forum) }
     end
 
     describe '#duration' do

--- a/spec/lib/video_info/providers/youtube_api_spec.rb
+++ b/spec/lib/video_info/providers/youtube_api_spec.rb
@@ -1,6 +1,10 @@
 require 'spec_helper'
 
 describe VideoInfo::Providers::Youtube do
+  before(:all) do
+    VideoInfo.provider_api_keys = { youtube: 'AIzaSyA6PYwSr1EnLFUFy1cZDk3Ifb0rxeJaeZ0' }
+  end
+
   describe ".usable?" do
     subject { VideoInfo::Providers::Youtube.usable?(url) }
 

--- a/spec/lib/video_info/providers/youtube_playlist_api_spec.rb
+++ b/spec/lib/video_info/providers/youtube_playlist_api_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe VideoInfo::Providers::YoutubePlaylist do
-  before(:all) do
+  before(:each) do
     VideoInfo.provider_api_keys = { youtube: 'AIzaSyA6PYwSr1EnLFUFy1cZDk3Ifb0rxeJaeZ0' }
   end
 
@@ -94,7 +94,7 @@ describe VideoInfo::Providers::YoutubePlaylist do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to be_nil }
+      it { is_expected.to eq ['video', 'sharing', 'camera phone', 'video phone', 'free', 'upload']  }
     end
 
     describe '#duration' do

--- a/spec/lib/video_info/providers/youtube_playlist_api_spec.rb
+++ b/spec/lib/video_info/providers/youtube_playlist_api_spec.rb
@@ -94,7 +94,7 @@ describe VideoInfo::Providers::YoutubePlaylist do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to eq ['video', 'sharing', 'camera phone', 'video phone', 'free', 'upload']  }
+      it { is_expected.to be_nil }
     end
 
     describe '#duration' do

--- a/spec/lib/video_info/providers/youtube_playlist_spec.rb
+++ b/spec/lib/video_info/providers/youtube_playlist_spec.rb
@@ -94,7 +94,7 @@ describe VideoInfo::Providers::YoutubePlaylist do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to eq ['video', 'sharing', 'camera phone', 'video phone', 'free', 'upload'] }
+      it { is_expected.to be_nil }
     end
 
     describe '#duration' do

--- a/spec/lib/video_info/providers/youtube_playlist_spec.rb
+++ b/spec/lib/video_info/providers/youtube_playlist_spec.rb
@@ -94,7 +94,7 @@ describe VideoInfo::Providers::YoutubePlaylist do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to be_nil }
+      it { is_expected.to eq ['video', 'sharing', 'camera phone', 'video phone', 'free', 'upload'] }
     end
 
     describe '#duration' do
@@ -153,7 +153,7 @@ describe VideoInfo::Providers::YoutubePlaylist do
 
     describe '#videos' do
       subject { super().videos }
-      it { expect { subject }.to raise_error(NotImplementedError) } 
+      it { expect { subject }.to raise_error(NotImplementedError) }
     end
   end
 

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -164,7 +164,7 @@ describe VideoInfo::Providers::Youtube do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to be ['cherry' 'bloom' 'king' 'of' 'the' 'knife' 'guitar' 'drum' 'clip' 'rock' 'alternative' 'tremplin' 'Paris-Forum']}
+      it { is_expected.to be ['cherry' 'bloom' 'king' 'of' 'the' 'knife' 'guitar' 'drum' 'clip' 'rock' 'alternative' 'tremplin' 'Paris-Forum'] }
     end
 
     describe '#duration' do

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -164,7 +164,7 @@ describe VideoInfo::Providers::Youtube do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to be_nil }
+      it { is_expected.to be ['cherry' 'bloom' 'king' 'of' 'the' 'knife' 'guitar' 'drum' 'clip' 'rock' 'alternative' 'tremplin' 'Paris-Forum']}
     end
 
     describe '#duration' do

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -184,7 +184,7 @@ describe VideoInfo::Providers::Youtube do
 
     describe '#date' do
       subject { super().date }
-      it { is_expected.to eq Time.parse('Sat Apr 12 22:25:35 UTC 2008', Time.now.utc) }
+      it { is_expected.to eq Time.parse('Sat Apr 12 2008', Time.now.utc) }
     end
 
     describe '#thumbnail_small' do

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -164,7 +164,7 @@ describe VideoInfo::Providers::Youtube do
 
     describe '#keywords' do
       subject { super().keywords }
-      it { is_expected.to be ['cherry' 'bloom' 'king' 'of' 'the' 'knife' 'guitar' 'drum' 'clip' 'rock' 'alternative' 'tremplin' 'Paris-Forum'] }
+      it { is_expected.to eq %w(cherry bloom king of the knife guitar drum clip rock alternative tremplin Paris-Forum) }
     end
 
     describe '#duration' do


### PR DESCRIPTION
This is pretty much done, except for a few things:
* ~~THE INEVITABLE FLOOD OF HOUNDCI VIOLATIONS WOOO~~ Fewer than I expected
* ~~I should clean it up a bit. `#date`, `#description`, and a few other functions can have the bulk moved to a single helper function.~~ 
* ~~I apparently broke some YoutubePlaylist stuff in the process~~ ~~Most is fixed. Just need to get `#keywords` working on the API.~~ Done
* ~~Update documentation since an API key isn't required for most things anymore~~
  * ~~Note that the scraper only includes the date posted. API is required to get exact time.~~ DONE
* ~~I have a question about the spec. For `#keywords`, I'm getting this failed spec:~~

```ruby
  1) VideoInfo::Providers::Youtube with video mZqGqE0D0n4 #keywords should be nil
     Failure/Error: it { is_expected.to be_nil }
       expected: nil
            got: "cherry, bloom, king, of, the, knife, guitar, drum, clip, rock, alternative, tremplin, Paris-Forum"
     # ./spec/lib/video_info/providers/youtube_spec.rb:167:in `block (4 levels) in <top (required)>'
```

~~I assume the spec is wrong, but it passes with the API. The API code is probably doing something wrong. I'll have a better look in a day or two when I finish this. Opened this so I could document what I have to do next~~ Fixed the spec. 