### PR TITLE
Feature Vimeo v3

### DIFF
--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -21,6 +21,7 @@ class VideoInfo
   def_delegators :@provider, :embed_code, :embed_url
   def_delegators :@provider, :available?
   def_delegators :@provider, :playlist_id, :videos
+  def_delegators :@provider, :data=
 
   def initialize(url, options = {})
     @provider = _select_provider(url, options)

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -17,7 +17,8 @@ class VideoInfo
   def_delegators :@provider, :provider, :video_id, :video_owner, :url, :data
   def_delegators :@provider, :title, :description, :keywords, :view_count
   def_delegators :@provider, :date, :duration, :width, :height
-  def_delegators :@provider, :thumbnail, :thumbnail_small, :thumbnail_medium, :thumbnail_large
+  def_delegators :@provider, :thumbnail
+  def_delegators :@provider, :thumbnail_small, :thumbnail_medium, :thumbnail_large
   def_delegators :@provider, :embed_code, :embed_url
   def_delegators :@provider, :available?
   def_delegators :@provider, :playlist_id, :videos

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -17,12 +17,13 @@ class VideoInfo
   def_delegators :@provider, :provider, :video_id, :video_owner, :url, :data
   def_delegators :@provider, :title, :description, :keywords, :view_count
   def_delegators :@provider, :date, :duration, :width, :height
-  def_delegators :@provider, :thumbnail_small, :thumbnail_medium, :thumbnail_large
+  def_delegators :@provider, :thumbnail, :thumbnail_small, :thumbnail_medium, :thumbnail_large
   def_delegators :@provider, :embed_code, :embed_url
   def_delegators :@provider, :available?
   def_delegators :@provider, :playlist_id, :videos
+  def_delegators :@provider, :author, :author_thumbnail
   def_delegators :@provider, :data=
-
+  
   def initialize(url, options = {})
     @provider = _select_provider(url, options)
   end

--- a/lib/video_info/provider.rb
+++ b/lib/video_info/provider.rb
@@ -50,14 +50,14 @@ class VideoInfo
     end
 
     def _http_response_code(http)
-      response = http.head(_api_path, @options) 
+      response = http.head(_api_path, @options)
       response.code
     end
 
     def _https_response_code(http)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-      response = http.head(_api_path, @options) 
+      response = http.head(_api_path, @options)
       response.code
     end
 

--- a/lib/video_info/provider.rb
+++ b/lib/video_info/provider.rb
@@ -39,8 +39,25 @@ class VideoInfo
     private
 
     def _response_code
-      response = nil
-      Net::HTTP.start(_api_base, 80) { |http| response = http.head(_api_path) }
+      uri = URI.parse(_api_url)
+      http = Net::HTTP.new(uri.host, uri.port)
+
+      if (uri.scheme == 'https')
+        _https_response_code(http)
+      else
+        _http_response_code(http)
+      end
+    end
+
+    def _http_response_code(http)
+      response = http.head(_api_path, @options) 
+      response.code
+    end
+
+    def _https_response_code(http)
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      response = http.head(_api_path, @options) 
       response.code
     end
 

--- a/lib/video_info/providers/vimeo.rb
+++ b/lib/video_info/providers/vimeo.rb
@@ -30,7 +30,8 @@ class VideoInfo
       end
 
       def author_thumbnail_id
-        @author_thumbnail_id ||= _parse_picture_id(_video['user']['pictures']['uri'])
+        author_uri = _video['user']['pictures']['uri']
+        @author_thumbnail_id ||= _parse_picture_id(author_uri)
       end
 
       def author_thumbnail(width = 75)

--- a/lib/video_info/providers/vimeo.rb
+++ b/lib/video_info/providers/vimeo.rb
@@ -25,16 +25,37 @@ class VideoInfo
         _video['name']
       end
 
+      def author
+        _video['user']['name']
+      end
+
+      def author_thumbnail_id
+        @author_thumbnail_id ||= _parse_picture_id(_video['user']['pictures']['uri'])
+      end
+
+      def author_thumbnail(width=75)
+        "https://i.vimeocdn.com/portrait/#{author_thumbnail_id}_#{width}x#{width}.jpg"
+      end
+
+      def thumbnail_id
+        @thumbnail_id ||= _parse_picture_id(_video['pictures']['uri'])
+      end
+
+      def thumbnail(width=200, height=nil)
+        base_uri = "https://i.vimeocdn.com/video/#{thumbnail_id}"
+        height ? base_uri + "_#{width}x#{height}.jpg" : base_uri + "_#{width}.jpg"
+      end
+      
       def thumbnail_small
-        "https://i.vimeocdn.com/video/#{video_id}_100x75.jpg"
+        thumbnail(100,75)
       end
 
       def thumbnail_medium
-        "https://i.vimeocdn.com/video/#{video_id}_200x150.jpg"
+        thumbnail(200,150)
       end
 
       def thumbnail_large
-        "https://i.vimeocdn.com/video/#{video_id}_640.jpg"
+        thumbnail(640)
       end
 
       def keywords
@@ -105,6 +126,10 @@ class VideoInfo
           byline: 0,
           portrait: 0,
           autoplay: 0 }
+      end
+
+      def _parse_picture_id(uri)
+        /\/pictures\/(\d+)/.match(uri)[1]
       end
     end
   end

--- a/lib/video_info/providers/vimeo.rb
+++ b/lib/video_info/providers/vimeo.rb
@@ -42,7 +42,7 @@ class VideoInfo
       end
 
       def keywords_array
-        _video['tags'].map { |t| t["tag"] }
+        _video['tags'].map { |t| t['tag'] }
       end
 
       def embed_url
@@ -54,7 +54,7 @@ class VideoInfo
       end
 
       def view_count
-        _video['stats']["plays"].to_i
+        _video['stats']['plays'].to_i
       end
 
       private
@@ -65,15 +65,15 @@ class VideoInfo
       end
 
       def _api_version
-        "3.2"
+        '3.2'
       end
 
       def _authorization_headers
-        { "Authorization" => "bearer #{api_key}" }
+        { 'Authorization' => "bearer #{api_key}" }
       end
 
       def _api_version_headers
-        { "Accept" => "application/vnd.vimeo.*+json;version=#{_api_version}"}
+        { 'Accept' => "application/vnd.vimeo.*+json;version=#{_api_version}" }
       end
 
       def _video

--- a/lib/video_info/providers/vimeo.rb
+++ b/lib/video_info/providers/vimeo.rb
@@ -33,7 +33,7 @@ class VideoInfo
         @author_thumbnail_id ||= _parse_picture_id(_video['user']['pictures']['uri'])
       end
 
-      def author_thumbnail(width=75)
+      def author_thumbnail(width = 75)
         "https://i.vimeocdn.com/portrait/#{author_thumbnail_id}_#{width}x#{width}.jpg"
       end
 
@@ -41,17 +41,17 @@ class VideoInfo
         @thumbnail_id ||= _parse_picture_id(_video['pictures']['uri'])
       end
 
-      def thumbnail(width=200, height=nil)
+      def thumbnail(width = 200, height = nil)
         base_uri = "https://i.vimeocdn.com/video/#{thumbnail_id}"
         height ? base_uri + "_#{width}x#{height}.jpg" : base_uri + "_#{width}.jpg"
       end
-      
+
       def thumbnail_small
-        thumbnail(100,75)
+        thumbnail(100, 75)
       end
 
       def thumbnail_medium
-        thumbnail(200,150)
+        thumbnail(200, 150)
       end
 
       def thumbnail_large

--- a/lib/video_info/providers/vimeo.rb
+++ b/lib/video_info/providers/vimeo.rb
@@ -9,7 +9,11 @@ class VideoInfo
         'Vimeo'
       end
 
-      %w[title description thumbnail_small thumbnail_medium thumbnail_large].each do |method|
+      def api_key
+        VideoInfo.provider_api_keys[:vimeo]
+      end
+
+      %w[description].each do |method|
         define_method(method) { _video[method] }
       end
 
@@ -17,8 +21,28 @@ class VideoInfo
         define_method(method) { _video[method].to_i }
       end
 
+      def title
+        _video['name']
+      end
+
+      def thumbnail_small
+        "https://i.vimeocdn.com/video/#{video_id}_100x75.jpg"
+      end
+
+      def thumbnail_medium
+        "https://i.vimeocdn.com/video/#{video_id}_200x150.jpg"
+      end
+
+      def thumbnail_large
+        "https://i.vimeocdn.com/video/#{video_id}_640.jpg"
+      end
+
       def keywords
-        _video['tags']
+        keywords_array.join(', ')
+      end
+
+      def keywords_array
+        _video['tags'].map { |t| t["tag"] }
       end
 
       def embed_url
@@ -26,17 +50,34 @@ class VideoInfo
       end
 
       def date
-        Time.parse(_video['upload_date'], Time.now.utc).utc
+        Time.parse(_video['created_time'], Time.now.utc).utc
       end
 
       def view_count
-        _video['stats_number_of_plays'].to_i
+        _video['stats']["plays"].to_i
       end
 
       private
 
+      def _clean_options(options)
+        headers = [super, _authorization_headers, _api_version_headers]
+        headers.inject(&:merge)
+      end
+
+      def _api_version
+        "3.2"
+      end
+
+      def _authorization_headers
+        { "Authorization" => "bearer #{api_key}" }
+      end
+
+      def _api_version_headers
+        { "Accept" => "application/vnd.vimeo.*+json;version=#{_api_version}"}
+      end
+
       def _video
-        data && data.first
+        data
       end
 
       def _url_regex
@@ -44,15 +85,15 @@ class VideoInfo
       end
 
       def _api_base
-        'vimeo.com'
+        'api.vimeo.com'
       end
 
       def _api_path
-        "/api/v2/video/#{video_id}.json"
+        "/videos/#{video_id}"
       end
 
       def _api_url
-        "http://#{_api_base}#{_api_path}"
+        "https://#{_api_base}#{_api_path}"
       end
 
       def _default_iframe_attributes

--- a/lib/video_info/providers/vimeoplaylist.rb
+++ b/lib/video_info/providers/vimeoplaylist.rb
@@ -58,7 +58,6 @@ class VideoInfo
         json = MultiJson.load(uri.read)
         json['data']
       end
-
     end
   end
 end

--- a/lib/video_info/providers/vimeoplaylist.rb
+++ b/lib/video_info/providers/vimeoplaylist.rb
@@ -8,8 +8,10 @@ class VideoInfo
       end
 
       def videos
-        _playlist_video_ids.map do |entry_id|
-          VideoInfo.new("http://vimeo.com/#{entry_id}")
+        @videos ||= _data_videos.map do |video_data|
+          video = Vimeo.new(video_data['link'])
+          video.data = video
+          video
         end
       end
 
@@ -17,7 +19,7 @@ class VideoInfo
         "//player.vimeo.com/hubnut/album/#{playlist_id}"
       end
 
-      %w[width height date keywords duration view_count].each do |method|
+      %w[width height keywords view_count].each do |method|
         define_method(method) { nil }
       end
 
@@ -32,15 +34,19 @@ class VideoInfo
       end
 
       def _api_path
-        "/api/v2/album/#{video_id}/info.json"
+        "/albums/#{playlist_id}"
+      end
+
+      def _api_path_album_videos
+        "/albums/#{playlist_id}/videos"
       end
 
       def _api_videos_path
-        "/api/v2/album/#{video_id}/videos.json"
+        "/videos/#{video_id}"
       end
 
       def _api_videos_url
-        "http://#{_api_base}#{_api_videos_path}"
+        "https://#{_api_base}#{_api_path_album_videos}"
       end
 
       def _data_videos
@@ -49,14 +55,10 @@ class VideoInfo
 
       def _set_videos_from_api
         uri = open(_api_videos_url, options)
-        MultiJson.load(uri.read)
+        json = MultiJson.load(uri.read)
+        json['data']
       end
 
-      def _playlist_video_ids
-        _data_videos.map do |entry|
-          entry['id']
-        end
-      end
     end
   end
 end

--- a/spec/lib/video_info/providers/vimeo_playlist_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_playlist_spec.rb
@@ -122,17 +122,17 @@ describe VideoInfo::Providers::VimeoPlaylist do
 
     describe '#thumbnail_small' do
       subject { super().thumbnail_small }
-      it { is_expected.to eq 'https://i.vimeocdn.com/video/1921098_100x75.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/299773432_100x75.jpg' }
     end
 
     describe '#thumbnail_medium' do
       subject { super().thumbnail_medium }
-      it { is_expected.to eq 'https://i.vimeocdn.com/video/1921098_200x150.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/299773432_200x150.jpg' }
     end
 
     describe '#thumbnail_large' do
       subject { super().thumbnail_large }
-      it { is_expected.to eq 'https://i.vimeocdn.com/video/1921098_640.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/299773432_640.jpg' }
     end
 
     describe '#videos' do

--- a/spec/lib/video_info/providers/vimeo_playlist_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_playlist_spec.rb
@@ -2,35 +2,35 @@ require 'spec_helper'
 
 describe VideoInfo::Providers::VimeoPlaylist do
   before(:all) do
-    VideoInfo.provider_api_keys = { vimeo: '6b66b015a3504793b4f541d878f46ff6'}
+    VideoInfo.provider_api_keys = { vimeo: '6b66b015a3504793b4f541d878f46ff6' }
   end
 
-  describe ".usable?" do
+  describe '.usable?' do
     subject { VideoInfo::Providers::VimeoPlaylist.usable?(url) }
 
-    context "with vimeo album url" do
+    context 'with vimeo album url' do
       let(:url) { 'http://vimeo.com/album/2755718' }
       it { is_expected.to be_truthy }
     end
 
-    context "with vimeo hubnub embed url" do
+    context 'with vimeo hubnub embed url' do
       let(:url) { 'http://player.vimeo.com/hubnut/album/2755718' }
       it { is_expected.to be_truthy }
     end
 
-    context "with vimeo url" do
+    context 'with vimeo url' do
       let(:url) { 'http://www.vimeo.com/898029' }
       it { is_expected.to be_falsey }
     end
 
-    context "with other url" do
+    context 'with other url' do
       let(:url) { 'http://www.youtube.com/898029' }
       it { is_expected.to be_falsey }
     end
   end
 
-  describe "#available?" do
-    context "with valid playlist", :vcr do
+  describe '#available?' do
+    context 'with valid playlist', :vcr do
       subject { VideoInfo.new('http://vimeo.com/album/2755718') }
 
       describe '#available?' do
@@ -39,7 +39,7 @@ describe VideoInfo::Providers::VimeoPlaylist do
       end
     end
 
-    context "with invalid playlist", :vcr do
+    context 'with invalid playlist', :vcr do
       subject { VideoInfo.new('http://vimeo.com/album/2') }
 
       describe '#available?' do
@@ -49,8 +49,7 @@ describe VideoInfo::Providers::VimeoPlaylist do
     end
   end
 
-
-  context "with playlist 1921098", :vcr do
+  context 'with playlist 1921098', :vcr do
     let(:videos) {
       [
         39837353, 40170418, 38809325, 38445453,
@@ -147,7 +146,7 @@ describe VideoInfo::Providers::VimeoPlaylist do
     end
   end
 
-  context "with playlist 2755718 in embed path", :vcr do
+  context 'with playlist 2755718 in embed path', :vcr do
     subject { VideoInfo.new('http://player.vimeo.com/hubnut/album/2755718') }
 
     describe '#playlist_id' do
@@ -155,5 +154,4 @@ describe VideoInfo::Providers::VimeoPlaylist do
       it { is_expected.to eq '2755718' }
     end
   end
-
 end

--- a/spec/lib/video_info/providers/vimeo_playlist_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_playlist_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe VideoInfo::Providers::VimeoPlaylist do
+  before(:all) do
+    VideoInfo.provider_api_keys = { vimeo: '6b66b015a3504793b4f541d878f46ff6'}
+  end
 
   describe ".usable?" do
     subject { VideoInfo::Providers::VimeoPlaylist.usable?(url) }
@@ -53,7 +56,7 @@ describe VideoInfo::Providers::VimeoPlaylist do
         39837353, 40170418, 38809325, 38445453,
         38445381, 38445243, 38394965, 42647970
       ].map do |video_id|
-        VideoInfo.new("http://vimeo.com/#{video_id}")
+        VideoInfo.new("https://vimeo.com/#{video_id}")
       end
     }
     subject { VideoInfo.new('http://vimeo.com/album/1921098') }
@@ -100,7 +103,7 @@ describe VideoInfo::Providers::VimeoPlaylist do
 
     describe '#duration' do
       subject { super().duration }
-      it { is_expected.to be_nil }
+      it { is_expected.to eq 1254 }
     end
 
     describe '#width' do
@@ -115,22 +118,22 @@ describe VideoInfo::Providers::VimeoPlaylist do
 
     describe '#date' do
       subject { super().date }
-      it { is_expected.to be_nil }
+      it { is_expected.to eq Time.parse('2012-04-30T15:00:53+00:00', Time.now.utc).utc }
     end
 
     describe '#thumbnail_small' do
       subject { super().thumbnail_small }
-      it { is_expected.to eq 'http://i.vimeocdn.com/video/299773432_100x75.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/1921098_100x75.jpg' }
     end
 
     describe '#thumbnail_medium' do
       subject { super().thumbnail_medium }
-      it { is_expected.to eq 'http://i.vimeocdn.com/video/299773432_200x150.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/1921098_200x150.jpg' }
     end
 
     describe '#thumbnail_large' do
       subject { super().thumbnail_large }
-      it { is_expected.to eq 'http://i.vimeocdn.com/video/299773432_640.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/1921098_640.jpg' }
     end
 
     describe '#videos' do

--- a/spec/lib/video_info/providers/vimeo_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_spec.rb
@@ -130,17 +130,27 @@ describe VideoInfo::Providers::Vimeo do
 
     describe '#thumbnail_small' do
       subject { super().thumbnail_small }
-      it { is_expected.to eq 'https://i.vimeocdn.com/video/898029_100x75.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/34373130_100x75.jpg' }
     end
 
     describe '#thumbnail_medium' do
       subject { super().thumbnail_medium }
-      it { is_expected.to eq 'https://i.vimeocdn.com/video/898029_200x150.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/34373130_200x150.jpg' }
     end
 
     describe '#thumbnail_large' do
       subject { super().thumbnail_large }
-      it { is_expected.to eq 'https://i.vimeocdn.com/video/898029_640.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/34373130_640.jpg' }
+    end
+
+    describe '#author_thumbnail' do
+      subject { super().author_thumbnail }
+      it { is_expected.to eq 'https://i.vimeocdn.com/portrait/2577152_75x75.jpg' }
+    end
+
+    describe '#author' do
+      subject { super().author }
+      it { is_expected.to eq 'Octave Zangs' }
     end
 
     describe '#view_count' do

--- a/spec/lib/video_info/providers/vimeo_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe VideoInfo::Providers::Vimeo do
+  before(:all) do
+    VideoInfo.provider_api_keys = { vimeo: '6b66b015a3504793b4f541d878f46ff6'}
+  end
 
   describe ".usable?" do
     subject { VideoInfo::Providers::Vimeo.usable?(url) }
@@ -122,22 +125,22 @@ describe VideoInfo::Providers::Vimeo do
 
     describe '#date' do
       subject { super().date }
-      it { is_expected.to eq Time.parse('2008-04-14 13:10:39', Time.now.utc) }
+      it { is_expected.to eq Time.parse('2008-04-14T17:10:39+00:00', Time.now.utc).utc }
     end
 
     describe '#thumbnail_small' do
       subject { super().thumbnail_small }
-      it { is_expected.to eq 'http://i.vimeocdn.com/video/34373130_100x75.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/898029_100x75.jpg' }
     end
 
     describe '#thumbnail_medium' do
       subject { super().thumbnail_medium }
-      it { is_expected.to eq 'http://i.vimeocdn.com/video/34373130_200x150.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/898029_200x150.jpg' }
     end
 
     describe '#thumbnail_large' do
       subject { super().thumbnail_large }
-      it { is_expected.to eq 'http://i.vimeocdn.com/video/34373130_640.jpg' }
+      it { is_expected.to eq 'https://i.vimeocdn.com/video/898029_640.jpg' }
     end
 
     describe '#view_count' do

--- a/spec/lib/video_info/providers/vimeo_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_spec.rb
@@ -2,45 +2,45 @@ require 'spec_helper'
 
 describe VideoInfo::Providers::Vimeo do
   before(:all) do
-    VideoInfo.provider_api_keys = { vimeo: '6b66b015a3504793b4f541d878f46ff6'}
+    VideoInfo.provider_api_keys = { vimeo: '6b66b015a3504793b4f541d878f46ff6' }
   end
 
-  describe ".usable?" do
+  describe '.usable?' do
     subject { VideoInfo::Providers::Vimeo.usable?(url) }
 
-    context "with vimeo url" do
+    context 'with vimeo url' do
       let(:url) { 'http://www.vimeo.com/898029' }
       it { is_expected.to be_truthy }
     end
 
-    context "with Vimeo OnDemand url" do
+    context 'with Vimeo OnDemand url' do
       let(:url) { 'https://vimeo.com/ondemand/less/101677664' }
       it { is_expected.to be_truthy }
     end
 
-    context "with Vimeo Channels url" do
+    context 'with Vimeo Channels url' do
       let(:url) { 'https://vimeo.com/channels/any_channel/111431415' }
       it { is_expected.to be_truthy }
     end
 
-    context "with vimeo album url" do
+    context 'with vimeo album url' do
       let(:url) { 'http://vimeo.com/album/2755718' }
       it { is_expected.to be_falsey }
     end
 
-    context "with vimeo hubnub embed url" do
+    context 'with vimeo hubnub embed url' do
       let(:url) { 'http://player.vimeo.com/hubnut/album/2755718' }
       it { is_expected.to be_falsey }
     end
 
-    context "with other url" do
+    context 'with other url' do
       let(:url) { 'http://www.youtube.com/898029' }
       it { is_expected.to be_falsey }
     end
   end
 
-  describe "#available?" do
-    context "with valid video", :vcr do
+  describe '#available?' do
+    context 'with valid video', :vcr do
       subject { VideoInfo.new('http://www.vimeo.com/898029') }
 
       describe '#available?' do
@@ -65,7 +65,7 @@ describe VideoInfo::Providers::Vimeo do
     end
   end
 
-  context "with video 898029", :vcr do
+  context 'with video 898029', :vcr do
     subject { VideoInfo.new('http://www.vimeo.com/898029') }
 
     describe '#provider' do
@@ -149,20 +149,20 @@ describe VideoInfo::Providers::Vimeo do
     end
   end
 
-  context "with video 898029 and url_attributes", :vcr do
+  context 'with video 898029 and url_attributes', :vcr do
     subject { VideoInfo.new('http://www.vimeo.com/898029') }
 
     it { expect(subject.embed_code(url_attributes: { autoplay: 1 })).to match(/autoplay=1/) }
   end
 
-  context "with video 898029 and iframe_attributes", :vcr do
+  context 'with video 898029 and iframe_attributes', :vcr do
     subject { VideoInfo.new('http://www.vimeo.com/898029') }
 
     it { expect(subject.embed_code(iframe_attributes: { width: 800, height: 600 })).to match(/width="800"/) }
     it { expect(subject.embed_code(iframe_attributes: { width: 800, height: 600 })).to match(/height="600"/) }
   end
 
-  context "with video 898029 in /group/ url", :vcr do
+  context 'with video 898029 in /group/ url', :vcr do
     subject { VideoInfo.new('http://vimeo.com/groups/1234/videos/898029') }
 
     describe '#provider' do
@@ -176,7 +176,7 @@ describe VideoInfo::Providers::Vimeo do
     end
   end
 
-  context "with video 898029 in /group/ url", :vcr do
+  context 'with video 898029 in /group/ url', :vcr do
     subject { VideoInfo.new('http://player.vimeo.com/video/898029') }
 
     describe '#provider' do
@@ -190,7 +190,7 @@ describe VideoInfo::Providers::Vimeo do
     end
   end
 
-  context "with video 898029 in text", :vcr do
+  context 'with video 898029 in text', :vcr do
     subject { VideoInfo.new('<a href="http://www.vimeo.com/898029">http://www.vimeo.com/898029</a>') }
 
     describe '#provider' do
@@ -204,18 +204,17 @@ describe VideoInfo::Providers::Vimeo do
     end
   end
 
-  context "with video 101677664 in /ondemand/ url", :vcr do
+  context 'with video 101677664 in /ondemand/ url', :vcr do
     subject { VideoInfo.new('https://vimeo.com/ondemand/less/101677664') }
 
     its(:provider) { should eq 'Vimeo' }
     its(:video_id) { should eq '101677664' }
   end
 
-  context "with video 111431415 in /channels/*/ url", :vcr do
+  context 'with video 111431415 in /channels/*/ url', :vcr do
     subject { VideoInfo.new('https://vimeo.com/channels/some_channel1/111431415') }
 
     its(:provider) { should eq 'Vimeo' }
     its(:video_id) { should eq '111431415' }
   end
-
 end


### PR DESCRIPTION
Updates Vimeo provider to version 3 of Vimeo's API.

Vimeo API v2 has been deprecated.  Version 3 now requires an access token for API calls.  This also allows video_info to fetch a users private videos.