### PR TITLE
fix: when extracting view_count from a page, remove all non digit chars

### DIFF
--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -47,7 +47,7 @@ class VideoInfo
       end
 
       def view_count
-        data.css('div.watch-view-count').text.gsub(',', '').to_i
+        data.css('div.watch-view-count').text.gsub(/\D/, '').to_i
       end
 
       private


### PR DESCRIPTION
This fixes the failing test of the view count. The gsub was looking for wrong pattern to match when extracting the view_count.