### PR TITLE
Detect possible API key problem and log a warning msg

### DIFF
--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -2,11 +2,23 @@ require 'video_info/version'
 require 'video_info/provider'
 require 'forwardable'
 require 'net/http'
+require 'logger'
 
 class VideoInfo
   class Error < StandardError; end
   class UrlError < Error; end
   class HttpError < Error; end
+
+  class << self
+    attr_writer :logger
+
+    def logger
+      @logger ||= Logger.new($stdout).tap do |lgr|
+        lgr.progname = name
+      end
+    end
+  end
+
   extend Forwardable
 
   PROVIDERS = %w[

--- a/lib/video_info/providers/youtube_api.rb
+++ b/lib/video_info/providers/youtube_api.rb
@@ -34,7 +34,9 @@ class VideoInfo
       private
 
       def available?
-        data['items'].size > 0 rescue false
+        data['items'].size > 0
+      rescue VideoInfo::HttpError
+        false
       end
 
       def _api_base

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -36,6 +36,25 @@ describe VideoInfo::Providers::Youtube do
       end
     end
 
+    context 'with valid video and invalid API key' do
+      subject { VideoInfo.new('http://www.youtube.com/watch?v=mZqGqE0D0n4') }
+      let(:msg) { 'your API key is probably invalid. Please verify it.' }
+      before do
+        VideoInfo.provider_api_keys[:youtube] = 'invalid_key'
+      end
+
+      after do
+        VideoInfo.provider_api_keys[:youtube] = nil
+      end
+
+      describe '#available?' do
+        it 'logs warning message to alert user about invalid API key' do
+          expect(VideoInfo.logger).to receive(:warn).with(msg)
+          subject.title
+        end
+      end
+    end
+
     context "with 'video is unavailable' video", :vcr do
       subject { VideoInfo.new('http://www.youtube.com/watch?v=SUkXvWn1m7Q') }
 


### PR DESCRIPTION
Logs a Warning message to alert the user to a possible issue related to API token and throws an HttpError to be handled as intended. #86 