### PR TITLE
Vimeo#keywords now returns an array instead of a string

### DIFF
--- a/lib/video_info/providers/vimeo_api.rb
+++ b/lib/video_info/providers/vimeo_api.rb
@@ -61,7 +61,7 @@ class VideoInfo
       end
 
       def keywords
-        keywords_array.join(', ')
+        keywords_array
       end
 
       def keywords_array

--- a/lib/video_info/providers/vimeo_scraper.rb
+++ b/lib/video_info/providers/vimeo_scraper.rb
@@ -63,11 +63,7 @@ class VideoInfo
       end
 
       def keywords
-        keywords_str = ''
-
-        json_info['keywords'].each { |keyword| keywords_str << keyword << ', ' }
-
-        keywords_str.chop.chop # remove trailing ", "
+        json_info['keywords']
       end
 
       def height

--- a/spec/lib/video_info/providers/vimeo_api_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_api_spec.rb
@@ -117,8 +117,9 @@ describe VideoInfo::Providers::Vimeo do
     describe '#keywords' do
       subject { super().keywords }
       it 'should return a string list of keywords' do
-        is_expected.to eq 'cherry bloom, secret sounds, ' \
-                          'king of the knife, rock, alternative'
+        keywords_list = ['cherry bloom', 'secret sounds',
+                         'king of the knife', 'rock', 'alternative']
+        is_expected.to eq keywords_list
       end
     end
 

--- a/spec/lib/video_info/providers/vimeo_spec.rb
+++ b/spec/lib/video_info/providers/vimeo_spec.rb
@@ -121,8 +121,9 @@ describe VideoInfo::Providers::Vimeo do
     describe '#keywords' do
       subject { super().keywords }
       it 'should have correct keywords as string' do
-        is_expected.to eq 'cherry bloom, secret sounds, ' \
-                          'king of the knife, rock, alternative'
+        keywords_list = ['cherry bloom', 'secret sounds',
+                         'king of the knife', 'rock', 'alternative']
+        is_expected.to eq keywords_list
       end
     end
 


### PR DESCRIPTION
Pretty simple fix. 