### PR TITLE
added Contributing guidelines to README 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+Contributing
+--------
+
+The guidelines for contributions are as follows:
+* Make sure you include comprehensive specs for new features and bug-fixes
+* Make sure all of the specs pass by running `rspec` in the root project directory. Pull requests with failing tests will not be merged.
+* Make sure there are no style issues by running `rubocop` in the root project directory. Pull requests with style issues will not be merged
+* Optimally, you should create a separate branch to make rebasing with `master` simpler if other work gets merged in before your patch does.
+

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ video = VideoInfo.new('http://vk.com/video39576223_108370515')
 # video.provider         => "Vkontakte"
 # video.video_id         => "108370515"
 # video.author           => "Alexander Maslov"
-# video.author_thumbnail => "https://pp.vk.me/c624521/v624521223/3c288/lVcVW7LNnrQ.jpg" 
+# video.author_thumbnail => "https://pp.vk.me/c624521/v624521223/3c288/lVcVW7LNnrQ.jpg"
 # video.author_url       => "https://vk.com/videos39576223"
 # video.title            => "Я уточка)))))"
 # video.description      => "это ВЗРЫВ МОЗГА!!!<br>Просто отвал башки..."
@@ -176,14 +176,6 @@ VideoInfo.disable_providers = [] # enable all providers
 Note: `disable_providers` is case-insensitive. Attempting to use a disabled provider will raise a UrlError, just like attempting to use a
 non-video URL.
 
-Contributing
---------
-
-The guidelines for contributions are as follows:
-* Make sure you include comprehensive specs for new features and bug-fixes
-* Make sure all of the specs pass by running `rspec` in the root project directory. Pull requests with failing tests will not be merged.
-* Make sure there are no style issues by running `rubocop` in the root project directory. Pull requests with style issues will not be merged
-* Optimally, you should create a separate branch to make rebasing with `master` simpler if other work gets merged in before your patch does.
 
 Author
 ------

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Maintainers
 -----------
 
 [Thibaud Guillaume-Gentil](https://github.com/thibaudgg) ([@thibaudgg](https://twitter.com/thibaudgg))
+
 [Vincent Heuken](https://github.com/vheuken) ([@vheuken](https://github.com/vheuken))
 
 Contributors

--- a/README.md
+++ b/README.md
@@ -176,6 +176,15 @@ VideoInfo.disable_providers = [] # enable all providers
 Note: `disable_providers` is case-insensitive. Attempting to use a disabled provider will raise a UrlError, just like attempting to use a
 non-video URL.
 
+Contributing
+--------
+
+The guidelines for contributions are as follows:
+* Make sure you include comprehensive specs for new features and bug-fixes
+* Make sure all of the specs pass by running `rspec` in the root project directory. Pull requests with failing tests will not be merged.
+* Make sure there are no style issues by running `rubocop` in the root project directory. Pull requests with style issues will not be merged
+* Optimally, you should create a separate branch to make rebasing with `master` simpler if other work gets merged in before your patch does.
+
 Author
 ------
 


### PR DESCRIPTION
I added a section for contributing guidelines, since none existed.

@thibaudgg Maybe we should consider splitting up the README a bit into different files? It is getting quite long. I can do that to this PR if you're interested. 