### PR TITLE
Return 50 playlistItems from Youtube playlist info

### DIFF
--- a/lib/video_info/providers/youtubeplaylist_api.rb
+++ b/lib/video_info/providers/youtubeplaylist_api.rb
@@ -56,7 +56,7 @@ class VideoInfo
 
     def _playlist_items_api_path
       '/youtube/v3/playlistItems?part=snippet&' \
-      "playlistId=#{playlist_id}&fields=items&key=#{api_key}"
+      "playlistId=#{playlist_id}&fields=items&key=#{api_key}&maxResults=50"
     end
 
     def _playlist_items_api_url


### PR DESCRIPTION
By default Youtube returns only 5 playlistItems from playlist. Propose to set max value.
https://developers.google.com/apis-explorer/#p/youtube/v3/youtube.playlistItems.list?part=snippet%252CcontentDetails&playlistId=PLBCF2DAC6FFB574DE&_h=2&

https://developers.google.com/youtube/v3/code_samples/code_snippets