### PR TITLE
Suppress warning

### DIFF
--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -10,8 +10,7 @@ class VideoInfo
   class HttpError < Error; end
 
   class << self
-    attr_writer :logger
-    attr_accessor :disable_providers, :provider_api_keys
+    attr_writer :logger, :disable_providers
 
     def disable_providers
       @disable_providers || []

--- a/lib/video_info/provider.rb
+++ b/lib/video_info/provider.rb
@@ -4,7 +4,8 @@ require 'uri'
 
 class VideoInfo
   class Provider
-    attr_accessor :url, :options, :iframe_attributes, :video_id, :data
+    attr_accessor :url, :options, :iframe_attributes, :video_id
+    attr_writer :data
 
     def initialize(url, options = {})
       @options = _clean_options(options)
@@ -109,7 +110,7 @@ class VideoInfo
     end
 
     def _set_data_from_api_impl(api_url)
-      uri = open(api_url, options)
+      uri = URI.open(api_url, options)
       JSON.load(uri.read)
     end
 

--- a/lib/video_info/providers/vimeo_scraper.rb
+++ b/lib/video_info/providers/vimeo_scraper.rb
@@ -185,7 +185,7 @@ class VideoInfo
       end
 
       def _set_data_from_api_impl(api_url)
-        Oga.parse_html(open(api_url.to_s).read)
+        Oga.parse_html(URI.open(api_url.to_s).read)
 
       rescue OpenURI::HTTPError
         nil

--- a/lib/video_info/providers/youtube_api.rb
+++ b/lib/video_info/providers/youtube_api.rb
@@ -83,7 +83,7 @@ class VideoInfo
 
       def _channel_info
         channel_url = _channel_api_url(_video_snippet['channelId'])
-        @_channel_info ||=  JSON.load(open(channel_url).read)
+        @_channel_info ||=  JSON.load(URI.open(channel_url).read)
       end
 
       def _channel_snippet

--- a/lib/video_info/providers/youtube_scraper.rb
+++ b/lib/video_info/providers/youtube_scraper.rb
@@ -78,7 +78,7 @@ class VideoInfo
       end
 
       def channel_data
-        @channel_data ||= Oga.parse_html(open(author_url).read)
+        @channel_data ||= Oga.parse_html(URI.open(author_url).read)
       end
 
       def meta_node_value(meta_nodes=video_meta_nodes, name)
@@ -106,9 +106,9 @@ class VideoInfo
         if url.include?('.com/v/')
           video_id = url.split('/v/')[1].split('?')[0]
           new_url = 'https://www.youtube.com/watch?v=' + video_id
-          Oga.parse_html(open(new_url).read)
+          Oga.parse_html(URI.open(new_url).read)
         else
-          Oga.parse_html(open(api_url).read)
+          Oga.parse_html(URI.open(api_url).read)
         end
       end
 


### PR DESCRIPTION
This PR suppresses the following warning.

```
ruby -v
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-linux]

RUBYOPT=-w bundle exec rspec
video_info/lib/video_info/provider.rb:31: warning: method redefined; discarding old data
video_info/lib/video_info.rb:16: warning: method redefined; discarding old disable_providers
video_info/lib/video_info.rb:20: warning: method redefined; discarding old provider_api_keys
video_info/lib/video_info.rb:24: warning: method redefined; discarding old provider_api_keys=

video_info/lib/video_info/provider.rb:112: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
video_info/lib/video_info/providers/vimeo_scraper.rb:188: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
video_info/lib/video_info/providers/youtube_api.rb:86: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
video_info/lib/video_info/providers/youtube_scraper.rb:81: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
video_info/lib/video_info/providers/youtube_scraper.rb:109: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
video_info/lib/video_info/providers/youtube_scraper.rb:111: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```