### PR TITLE
Remove spec from files published on rubygems

### DIFF
--- a/video_info.gemspec
+++ b/video_info.gemspec
@@ -14,8 +14,7 @@ Gem::Specification.new do |s|
   s.summary      = 'Dailymotion, Vimeo and YouTube info parser.'
   s.description  = 'Get video info from Dailymotion, Vimeo and YouTube url.'
 
-  s.files        = `git ls-files`.split($/)
-  s.test_files   = s.files.grep(%r{^spec/})
+  s.files        = `git ls-files`.split($/).reject { |x| x.match?(%r{^spec/}) }
   s.require_path = 'lib'
 
   s.required_ruby_version = '>= 2.5.0'


### PR DESCRIPTION
Hello 👋 

### What is this PR?

Making sure that the `spec/` folder is not published to rubygems.
As RubyGems points out, the `test_files` option is ignored

### Why?

The fixtures are no use to the end user, and they inflate the project size. Heroku's slug size cap is 500 MB, the fixtures of this gem account for 19.3 MB. This change is important for us, as the limit of 500 MB has been reached.

Currently 👇 

![image](https://user-images.githubusercontent.com/16024169/107798173-11eb8a80-6d5c-11eb-93f7-10af7d183964.png)

After this PR:

![image](https://user-images.githubusercontent.com/16024169/107798258-2b8cd200-6d5c-11eb-9a3f-2dad3c98a0c9.png)

That is a decrease by 99.7%