### PR TITLE
Add valid_url? helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,17 @@ playlist = VideoInfo.new("http://www.youtube.com/playlist?p=PL9hW1uS6HUftLdHI6RI
 # playlist.videos              => [VideoInfo.new('http://www.youtube.com/watch?v=_Bt3-WsHfB0'), VideoInfo.new('http://www.youtube.com/watch?v=9g2U12SsRns'), VideoInfo.new('http://www.youtube.com/watch?v=8b0aEoxqqC0'), VideoInfo.new('http://www.youtube.com/watch?v=6c3mHikRz0I'), VideoInfo.new('http://www.youtube.com/watch?v=OQVHWsTHcoc')]
 ```
 
+You can also use the `valid_url?` helper to check if a given url is valid in some of the _enabled_ providers:
+
+```ruby
+> VideoInfo.valid_url?('http://www.youtube.com/watch?v=AT_5xOGh6Ko')
+=> true
+> VideoInfo.valid_url?('http://vimeo.com/898029')
+=> true
+> VideoInfo.valid_url?('http://www.example.com/video/12345')
+=> false
+```
+
 Options
 -------
 

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -81,6 +81,13 @@ class VideoInfo
     disable_providers.map(&:downcase).include?(provider.downcase)
   end
 
+  def self.valid_url?(url)
+    PROVIDERS.select { |p| !disabled_provider?(p) }.any? do |provider|
+      provider_const = Providers.const_get(provider)
+      return true if provider_const.usable?(url)
+    end
+  end
+
   private
 
   def _select_provider(url, options)

--- a/lib/video_info.rb
+++ b/lib/video_info.rb
@@ -81,11 +81,14 @@ class VideoInfo
     disable_providers.map(&:downcase).include?(provider.downcase)
   end
 
+  def self.enabled_providers
+    PROVIDERS
+      .reject { |p| disabled_provider?(p) }
+      .map { |p| Providers.const_get(p) }
+  end
+
   def self.valid_url?(url)
-    PROVIDERS.select { |p| !disabled_provider?(p) }.any? do |provider|
-      provider_const = Providers.const_get(provider)
-      return true if provider_const.usable?(url)
-    end
+    enabled_providers.any? { |p| p.usable?(url) }
   end
 
   private

--- a/spec/lib/video_info_spec.rb
+++ b/spec/lib/video_info_spec.rb
@@ -81,6 +81,17 @@ describe VideoInfo do
     end
   end
 
+  describe '.valid_url?' do
+    it 'checks if passed url is usable in some of the enabled providers' do
+      allow(VideoInfo::Providers::Dailymotion).to receive(:usable?) { false }
+
+      expect(VideoInfo.valid_url?('http://www.youtube.com/watch?v=AT_5xOGh6Ko')).to be_truthy
+      expect(VideoInfo.valid_url?('http://vimeo.com/86701482')).to be_truthy
+      expect(VideoInfo.valid_url?('http://www.dailymotion.com/video/x7lni3')).to be_falsey
+      expect(VideoInfo.valid_url?('http://example.com/video/ABC123456')).to be_falsey
+    end
+  end
+
   describe '#==' do
     let(:vi_a) { VideoInfo.new('http://www.youtube.com/watch?v=AT_5xOGh6Ko') }
     let(:vi_b) { VideoInfo.new('http://www.youtube.com/watch?v=AT_5xOGh6Ko') }


### PR DESCRIPTION
Closes #158

Add new helper `valid_url?` to check if a url is valid in some of the enabled providers:

```ruby
> VideoInfo.valid_url?('http://www.youtube.com/watch?v=AT_5xOGh6Ko')
=> true
> VideoInfo.valid_url?('http://vimeo.com/898029')
=> true
> VideoInfo.valid_url?('http://www.example.com/video/12345')
=> false
```