### PR TITLE
Remove Ruby 2.6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.6', '2.7', '3.0', '3.1', '3.2', 'head']
-    continue-on-error: ${{ endsWith(matrix.ruby, 'head') }}
+        ruby: ['2.7', '3.0', '3.1', '3.2', 'head']
     steps:
       - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Simple Ruby Gem to get video info from Dailymotion, Vimeo, Wistia and YouTube (with playlist).
 
-Tested against Ruby 2.6, 2.7, 3.0, 3.1 and 3.2.
+Tested against Ruby 2.7, 3.0, 3.1 and 3.2.
 
 ## Features
 

--- a/video_info.gemspec
+++ b/video_info.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.files = `git ls-files`.split($/).reject { |x| x.match?(%r{^spec/}) }
   s.require_path = "lib"
 
-  s.required_ruby_version = ">= 2.5.0"
+  s.required_ruby_version = ">= 2.7.0"
 
   s.add_dependency "iso8601", "~> 0.13.0"
   s.add_dependency "oga", "~> 3.4"


### PR DESCRIPTION
Ruby 2.6 is pretty EOL, so time to stick to 2.7 as the minimal.

ℹ️ https://endoflife.date/ruby