### PR TITLE
Recognize live and shorts YouTube URLs

### DIFF
--- a/lib/video_info/providers/youtube.rb
+++ b/lib/video_info/providers/youtube.rb
@@ -54,7 +54,7 @@ class VideoInfo
       private
 
       def _url_regex
-        %r{(?:youtube(?:-nocookie)?\.com/(?:[^/]+/.+/|(?:v|e(?:mbed)?)/|
+        %r{(?:youtube(?:-nocookie)?\.com/(?:[^/]+/.+/|(?:v|e(?:mbed)?|live|shorts)/|
            .*[?&]v=)|youtu\.be/)([^"&?/ ]{11})}x
       end
 

--- a/spec/lib/video_info/providers/youtube_spec.rb
+++ b/spec/lib/video_info/providers/youtube_spec.rb
@@ -17,6 +17,21 @@
         it { is_expected.to be_truthy }
       end
 
+      context "with embed url" do
+        let(:url) { "https://www.youtube.com/embed/JM9NgvjjVng" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "with live url" do
+        let(:url) { "https://www.youtube.com/live/SMhkA07Fbfs" }
+        it { is_expected.to be_truthy }
+      end
+
+      context "with shorts url" do
+        let(:url) { "https://youtube.com/shorts/MOcigdHkzhE" }
+        it { is_expected.to be_truthy }
+      end
+
       context "with other url" do
         let(:url) { "http://google.com/video1" }
         it { is_expected.to be_falsey }


### PR DESCRIPTION
Made a small modification to the YouTube provider regex to allow it to recognize live and shorts URLs. Resolves #229